### PR TITLE
Surface StreamMetrics as OpenAI usage chunk (#36)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,6 +169,8 @@ async for chunk in stream_events_as_sse(agent.astep_stream(), model_name):
 
 `stream_events_as_sse` is a pure async generator: no FastAPI, no logging, no side effects. It accepts any `AsyncIterator[StreamEvent]`, maps each event to an OpenAI chat-completion-chunk delta using only standard OpenAI wire fields (`reasoning_content`, `tool_calls`, `role:"tool"` + `tool_call_id`, `content`), and terminates with `[DONE]`. On exception from the source iterator it emits an error chunk before `[DONE]` so clients always see a clean termination.
 
+After the terminal `StreamComplete`, the serializer emits one additional chunk with `choices: []` and a top-level `usage` object -- matching OpenAI's `stream_options: {include_usage: true}` behaviour so token counts are visible to standard clients. The same chunk also carries a sibling `stream_metrics` object with TTFT, time-to-first-content, total time, inter-token latencies, and model/tool call counters drawn from `StreamMetrics`. Conforming OpenAI clients ignore the extension; dashboards and eval harnesses that know to look for it get richer instrumentation without a second endpoint. The sync (`stream: false`) response body carries the same `usage` + `stream_metrics` at the top level.
+
 ### Adding new wire formats
 
 Additional wire formats (OpenAI Responses API for LlamaStack, Anthropic Messages) follow the same convention: one module, one pure function, one explicit import path.

--- a/packages/fipsagents/src/fipsagents/serialization/openai_sse.py
+++ b/packages/fipsagents/src/fipsagents/serialization/openai_sse.py
@@ -32,6 +32,7 @@ from fipsagents.baseagent.events import (
     ReasoningDelta,
     StreamComplete,
     StreamEvent,
+    StreamMetrics,
     ToolCallDelta,
     ToolResultEvent,
 )
@@ -69,6 +70,42 @@ def _sse_chunk(
                 "finish_reason": finish_reason,
             }
         ],
+    }
+    return f"data: {json.dumps(chunk)}\n\n"
+
+
+def _usage_chunk(
+    completion_id: str,
+    model_name: str,
+    metrics: StreamMetrics,
+) -> str:
+    """Serialize a final usage chunk (OpenAI ``include_usage`` convention).
+
+    Shape matches OpenAI's ``stream_options: {include_usage: true}``
+    behaviour — a chunk with ``choices: []`` and a top-level ``usage``
+    object. We also attach a ``stream_metrics`` extension carrying
+    TTFT / ITL / counters that OpenAI's spec does not cover; unknown
+    fields are ignored by conforming clients.
+    """
+    chunk = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "created": _now(),
+        "model": model_name,
+        "choices": [],
+        "usage": {
+            "prompt_tokens": metrics.prompt_tokens,
+            "completion_tokens": metrics.completion_tokens,
+            "total_tokens": metrics.total_tokens,
+        },
+        "stream_metrics": {
+            "time_to_first_reasoning": metrics.time_to_first_reasoning,
+            "time_to_first_content": metrics.time_to_first_content,
+            "total_time": metrics.total_time,
+            "inter_token_latencies": metrics.inter_token_latencies,
+            "model_calls": metrics.model_calls,
+            "tool_calls": metrics.tool_calls,
+        },
     }
     return f"data: {json.dumps(chunk)}\n\n"
 
@@ -183,6 +220,9 @@ async def stream_events_as_sse(
                     {},
                     finish_reason=event.finish_reason,
                 )
+                # OpenAI's stream_options.include_usage appends a
+                # separate chunk with empty choices carrying usage.
+                yield _usage_chunk(completion_id, model_name, event.metrics)
 
     except Exception as exc:
         err = {"error": {"message": str(exc), "type": type(exc).__name__}}

--- a/packages/fipsagents/src/fipsagents/server/__init__.py
+++ b/packages/fipsagents/src/fipsagents/server/__init__.py
@@ -34,6 +34,7 @@ except ImportError as exc:  # pragma: no cover — helpful error path
     ) from exc
 
 from fipsagents.baseagent import BaseAgent
+from fipsagents.baseagent.events import ContentDelta, StreamComplete, StreamMetrics
 from fipsagents.serialization.openai_sse import stream_events_as_sse
 
 logger = logging.getLogger(__name__)
@@ -79,7 +80,14 @@ def _messages_to_dicts(messages: list[ChatMessage]) -> list[dict[str, Any]]:
     return out
 
 
-def _sync_response(model_name: str, content: str) -> dict[str, Any]:
+def _sync_response(
+    model_name: str,
+    content: str,
+    *,
+    metrics: StreamMetrics | None = None,
+    finish_reason: str = "stop",
+) -> dict[str, Any]:
+    m = metrics or StreamMetrics()
     return {
         "id": f"chatcmpl-{uuid.uuid4().hex[:24]}",
         "object": "chat.completion",
@@ -89,13 +97,21 @@ def _sync_response(model_name: str, content: str) -> dict[str, Any]:
             {
                 "index": 0,
                 "message": {"role": "assistant", "content": content},
-                "finish_reason": "stop",
+                "finish_reason": finish_reason,
             }
         ],
         "usage": {
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "total_tokens": 0,
+            "prompt_tokens": m.prompt_tokens,
+            "completion_tokens": m.completion_tokens,
+            "total_tokens": m.total_tokens,
+        },
+        "stream_metrics": {
+            "time_to_first_reasoning": m.time_to_first_reasoning,
+            "time_to_first_content": m.time_to_first_content,
+            "total_time": m.total_time,
+            "inter_token_latencies": m.inter_token_latencies,
+            "model_calls": m.model_calls,
+            "tool_calls": m.tool_calls,
         },
     }
 
@@ -190,10 +206,17 @@ class OpenAIChatServer:
         incoming = _messages_to_dicts(req.messages)
 
         if not req.stream:
-            async with self._agent_lock:
-                agent.messages = list(incoming)
-                result = await agent.run()
-            return JSONResponse(_sync_response(model_name, str(result)))
+            content, metrics, finish_reason = await self._collect_sync(
+                agent, incoming
+            )
+            return JSONResponse(
+                _sync_response(
+                    model_name,
+                    content,
+                    metrics=metrics,
+                    finish_reason=finish_reason,
+                )
+            )
 
         return StreamingResponse(
             self._stream(incoming, model_name),
@@ -204,6 +227,31 @@ class OpenAIChatServer:
                 "X-Accel-Buffering": "no",
             },
         )
+
+    # -- Sync ----------------------------------------------------------------
+
+    async def _collect_sync(
+        self,
+        agent: BaseAgent,
+        incoming: list[dict[str, Any]],
+    ) -> tuple[str, StreamMetrics | None, str]:
+        """Drive ``astep_stream`` for a non-streaming response.
+
+        Fully drains the iterator so any post-``StreamComplete`` hooks
+        in the subclass (e.g. memory writes) run to completion.
+        """
+        parts: list[str] = []
+        metrics: StreamMetrics | None = None
+        finish_reason = "stop"
+        async with self._agent_lock:
+            agent.messages = list(incoming)
+            async for event in agent.astep_stream(max_iterations=10):
+                if isinstance(event, ContentDelta):
+                    parts.append(event.content)
+                elif isinstance(event, StreamComplete):
+                    metrics = event.metrics
+                    finish_reason = event.finish_reason
+        return "".join(parts), metrics, finish_reason
 
     # -- Streaming -----------------------------------------------------------
 

--- a/packages/fipsagents/tests/test_serialization_openai_sse.py
+++ b/packages/fipsagents/tests/test_serialization_openai_sse.py
@@ -44,12 +44,20 @@ async def _collect(gen: AsyncIterator[str]) -> list[dict | str]:
 
 
 def _delta(parsed: dict) -> dict:
-    """Extract the delta dict from a parsed chunk."""
-    return parsed["choices"][0]["delta"]
+    """Extract the delta dict from a parsed chunk. Empty-choices chunks
+    (e.g. the trailing usage chunk) return ``{}`` so filter expressions
+    can safely call this on any chunk."""
+    choices = parsed.get("choices") or []
+    if not choices:
+        return {}
+    return choices[0]["delta"]
 
 
 def _finish_reason(parsed: dict) -> str | None:
-    return parsed["choices"][0]["finish_reason"]
+    choices = parsed.get("choices") or []
+    if not choices:
+        return None
+    return choices[0]["finish_reason"]
 
 
 # ---------------------------------------------------------------------------
@@ -137,14 +145,58 @@ async def test_tool_result_event_becomes_tool_role_chunk():
     assert d["content"] == "result text"
 
 
-async def test_stream_complete_emits_finish_reason_then_done():
+async def test_stream_complete_emits_finish_reason_then_usage_then_done():
     events = [StreamComplete(finish_reason="stop", metrics=StreamMetrics())]
     frames = await _collect(stream_events_as_sse(_iter(events), model_name="m"))
-    # role, complete chunk, [DONE]
-    assert len(frames) == 3
+    # role, finish_reason chunk, usage chunk, [DONE]
+    assert len(frames) == 4
     assert _delta(frames[1]) == {}
     assert _finish_reason(frames[1]) == "stop"
-    assert frames[2] == "[DONE]"
+    # Usage chunk: empty choices, usage + stream_metrics populated.
+    assert frames[2]["choices"] == []
+    assert "usage" in frames[2]
+    assert "stream_metrics" in frames[2]
+    assert frames[3] == "[DONE]"
+
+
+async def test_usage_chunk_carries_token_counts_and_stream_metrics():
+    metrics = StreamMetrics(
+        time_to_first_reasoning=0.05,
+        time_to_first_content=0.12,
+        total_time=1.5,
+        inter_token_latencies=[0.01, 0.02, 0.015],
+        prompt_tokens=42,
+        completion_tokens=17,
+        total_tokens=59,
+        model_calls=2,
+        tool_calls=1,
+    )
+    events = [StreamComplete(finish_reason="stop", metrics=metrics)]
+    frames = await _collect(stream_events_as_sse(_iter(events), model_name="m"))
+    usage_chunk = frames[2]
+    assert usage_chunk["usage"] == {
+        "prompt_tokens": 42,
+        "completion_tokens": 17,
+        "total_tokens": 59,
+    }
+    sm = usage_chunk["stream_metrics"]
+    assert sm["time_to_first_reasoning"] == 0.05
+    assert sm["time_to_first_content"] == 0.12
+    assert sm["total_time"] == 1.5
+    assert sm["inter_token_latencies"] == [0.01, 0.02, 0.015]
+    assert sm["model_calls"] == 2
+    assert sm["tool_calls"] == 1
+
+
+async def test_usage_chunk_shares_completion_id_and_model_name():
+    events = [StreamComplete(finish_reason="stop", metrics=StreamMetrics())]
+    frames = await _collect(
+        stream_events_as_sse(_iter(events), model_name="granite-8b", completion_id="cid-1")
+    )
+    json_frames = [f for f in frames if isinstance(f, dict)]
+    assert all(f["id"] == "cid-1" for f in json_frames)
+    assert all(f["model"] == "granite-8b" for f in json_frames)
+    assert all(f["object"] == "chat.completion.chunk" for f in json_frames)
 
 
 async def test_exception_in_source_yields_error_chunk_then_done():

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -104,11 +104,19 @@ def _parse_sse_body(body: str) -> list[dict | str]:
 
 
 def _delta(chunk: dict) -> dict:
-    return chunk["choices"][0]["delta"]
+    """Extract delta from a chunk; returns ``{}`` for empty-choices
+    chunks (e.g. the trailing usage chunk)."""
+    choices = chunk.get("choices") or []
+    if not choices:
+        return {}
+    return choices[0]["delta"]
 
 
 def _finish_reason(chunk: dict) -> str | None:
-    return chunk["choices"][0]["finish_reason"]
+    choices = chunk.get("choices") or []
+    if not choices:
+        return None
+    return choices[0]["finish_reason"]
 
 
 def _build_server(events=None, *, model_name: str = "stub-model") -> OpenAIChatServer:
@@ -163,6 +171,60 @@ def test_sync_chat_completions_returns_concatenated_content():
     assert body["choices"][0]["finish_reason"] == "stop"
 
 
+def test_sync_response_populates_usage_and_stream_metrics_from_metrics():
+    metrics = StreamMetrics(
+        time_to_first_content=0.07,
+        total_time=0.42,
+        inter_token_latencies=[0.01, 0.02],
+        prompt_tokens=11,
+        completion_tokens=5,
+        total_tokens=16,
+        model_calls=1,
+        tool_calls=0,
+    )
+    events = [
+        ContentDelta(content="ok"),
+        StreamComplete(finish_reason="stop", metrics=metrics),
+    ]
+    server = _build_server(events)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+        )
+    body = resp.json()
+    assert body["usage"] == {
+        "prompt_tokens": 11,
+        "completion_tokens": 5,
+        "total_tokens": 16,
+    }
+    sm = body["stream_metrics"]
+    assert sm["time_to_first_content"] == 0.07
+    assert sm["total_time"] == 0.42
+    assert sm["inter_token_latencies"] == [0.01, 0.02]
+    assert sm["model_calls"] == 1
+
+
+def test_sync_response_finish_reason_reflects_stream_complete():
+    events = [
+        ContentDelta(content="truncated"),
+        StreamComplete(finish_reason="length", metrics=StreamMetrics()),
+    ]
+    server = _build_server(events)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+        )
+    assert resp.json()["choices"][0]["finish_reason"] == "length"
+
+
 def test_streaming_chat_completions_emits_sse_frames():
     events = [
         ContentDelta(content="hi"),
@@ -197,6 +259,39 @@ def test_streaming_chat_completions_emits_sse_frames():
         if isinstance(f, dict) and _finish_reason(f) == "stop"
     ]
     assert len(stop_chunks) == 1
+
+
+def test_streaming_response_ends_with_usage_chunk_then_done():
+    metrics = StreamMetrics(
+        prompt_tokens=9,
+        completion_tokens=3,
+        total_tokens=12,
+        total_time=0.3,
+    )
+    events = [
+        ContentDelta(content="hi"),
+        StreamComplete(finish_reason="stop", metrics=metrics),
+    ]
+    server = _build_server(events)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "ping"}],
+                "stream": True,
+            },
+        )
+    frames = _parse_sse_body(resp.text)
+    assert frames[-1] == "[DONE]"
+    usage_chunk = frames[-2]
+    assert isinstance(usage_chunk, dict)
+    assert usage_chunk["choices"] == []
+    assert usage_chunk["usage"] == {
+        "prompt_tokens": 9,
+        "completion_tokens": 3,
+        "total_tokens": 12,
+    }
+    assert usage_chunk["stream_metrics"]["total_time"] == 0.3
 
 
 def test_streaming_tool_call_events_pass_through():


### PR DESCRIPTION
Closes #36.

## Summary

- Serializer emits a trailing `usage` chunk after `StreamComplete` matching OpenAI's `stream_options.include_usage` shape (`choices: []`, top-level `usage`).
- Same chunk carries a `stream_metrics` sibling for TTFT / ITL / total time / call counters — the parts of `StreamMetrics` that OpenAI's usage schema doesn't cover. Unknown fields are ignored by conforming clients, so this is strictly additive.
- Sync `/v1/chat/completions` response body now carries populated `usage` + `stream_metrics` drawn from the same `StreamComplete` event. Sync path consumes `astep_stream` directly instead of routing through `agent.run()` → `step()` → `astep_stream` (which dropped the metrics anyway).
- `finish_reason` in sync responses now reflects the actual `StreamComplete.finish_reason` rather than a hard-coded `"stop"`.

## Scope-discipline notes

Named the extension `stream_metrics` (matches the `StreamMetrics` dataclass); rejected `fips_metrics` — these are stream-level instrumentation, nothing to do with FIPS compliance.

No registries or strategy classes added. This is two helper functions (`_usage_chunk`, `_collect_sync`) and a new kwarg on `_sync_response`.

## Compat verification (pre-merge)

- `gateway-template` streaming: pure SSE line pass-through, terminates on `[DONE]`. Carries the new chunk through unchanged.
- `gateway-template` sync: `io.Copy(w, resp.Body)` — no schema assumptions.
- `ui-template` streaming: `parsed.choices?.[0]?.delta` optional chaining skips empty-choices chunks silently.

## Test plan

- [x] `pytest packages/fipsagents` — 393/393 green, including 5 new tests:
  - serializer: usage chunk follows `finish_reason` and precedes `[DONE]`
  - serializer: usage + `stream_metrics` carry expected values
  - serializer: completion_id + model_name shared across the usage chunk
  - server: sync response populates `usage` + `stream_metrics` from `StreamComplete.metrics`
  - server: sync response's `finish_reason` reflects `StreamComplete.finish_reason`
  - server: streaming response ends with usage chunk then `[DONE]`
- [ ] Redeploy `demo-chat-agent` and confirm `ui-template` continues to render without console errors (follow-up: wire TTFT/ITL display per #36 item 3).