### PR TITLE
Markdown memory backend (#44 Phase A)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,12 +276,46 @@ Memory is optional and pluggable. The `memory.backend` field in `agent.yaml` sel
 | Backend | Config file | Dependencies | Search type | Best for |
 |---------|-------------|--------------|-------------|----------|
 | `memoryhub` | `.memoryhub.yaml` | `memoryhub` | Full (server-side) | Production with MemoryHub |
+| `markdown` | `.memory-markdown.yaml` | None (stdlib) | Case-insensitive substring | Human-curated, git-committed memory |
 | `sqlite` | `.memory-sqlite.yaml` | None (stdlib) | Keyword (FTS5) | Local dev, testing |
 | `pgvector` | `.memory-pgvector.yaml` | `asyncpg`, `pgvector` | Semantic (vector cosine) | Production without MemoryHub |
 | `custom` | -- | Your choice | Your choice | Custom infrastructure |
 | `null` | -- | None | None (disabled) | Explicitly disable memory |
 
 When `backend` is unset, the factory auto-detects `.memoryhub.yaml` for backward compatibility. All backends implement `MemoryClientBase` with four async methods: `search()`, `write()`, `update()`, and `report_contradiction()`. When no backend is configured (or any backend fails to initialise), `self.memory` is a `NullMemoryClient` -- a silent no-op that returns empty results so agent code never needs to guard on configuration.
+
+### Picking a backend
+
+Memory implementations cluster into maturity levels; most teams should start at the simplest level that addresses their actual failure modes. The first decision is whether the agent needs memory at all:
+
+```
+Does this agent need memory across sessions?
+├─ No  → backend: null (or just leave it unset).
+└─ Yes → How will you curate it?
+   ├─ I'll read and edit the memory file by hand, and commit it to git
+   │  ├─ One topic       → backend: markdown, file: ./memory.md      (Level 1)
+   │  └─ Multiple areas  → backend: markdown, dir:  ./memories        (Level 2)
+   ├─ Agent needs searchable memory on one host, I won't curate by hand
+   │                     → backend: sqlite                            (Level 3)
+   ├─ Multiple agents share memory, or I need vector similarity
+   │                     → backend: pgvector                          (Level 4)
+   └─ Regulated environment: audit trails, RBAC, retention, deletion-with-evidence
+                           → backend: memoryhub                       (Level 5)
+```
+
+Each jump is a real jump, not a sliding scale of features. If you find yourself asking "should the markdown backend have search ranking?" the answer is usually "no, move to SQLite." The primer at `research/agent-memory-primer.md` goes into more detail on when each level is the right choice.
+
+### The prefix-cache pattern
+
+Regardless of backend, *how* an agent injects memory into the context affects prefix-cache hit rates at the model endpoint. Modern inference servers (vLLM, OpenAI, Anthropic) cache prefixes across requests; a turn whose first N tokens match the previous turn pays zero time-to-first-token for those tokens.
+
+Cache-friendly ordering looks like:
+
+1. System prompt (stable across turns)
+2. Memory block (stable across turns — inject once at session start, not re-query per turn)
+3. Conversation history (the changing part)
+
+The markdown backend's `search(query="")` is designed for this: it returns every section or file in stable file order as separate results, so an agent can load the whole memory set once and inject it as a stable prefix. Other backends (SQLite, PGVector, MemoryHub) can use the same pattern by retrieving once at session start and caching the result for the duration of the session. A first-class "memory prefix slot" in `BaseAgent` is a tracked follow-up.
 
 **The SDK path** exposes `self.memory` for programmatic access from agent code. This is for cases where the agent logic itself needs to read or write memories -- caching intermediate results, maintaining state across iterations, or implementing retrieval patterns that the LLM shouldn't control directly.
 

--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -187,6 +187,7 @@ class MemoryConfig(BaseModel):
 
     Supported backends:
       - ``memoryhub`` — MemoryHub SDK (requires ``memoryhub`` package)
+      - ``markdown``  — Human-readable markdown file(s) (zero dependencies)
       - ``sqlite``    — Local SQLite with FTS5 (zero dependencies)
       - ``pgvector``  — PostgreSQL + pgvector (requires ``asyncpg``)
       - ``custom``    — Bring your own: set ``backend_class`` to a dotted
@@ -194,7 +195,7 @@ class MemoryConfig(BaseModel):
       - ``null``      — Explicitly disable memory
     """
 
-    backend: Literal["memoryhub", "sqlite", "pgvector", "custom", "null"] | None = None
+    backend: Literal["memoryhub", "markdown", "sqlite", "pgvector", "custom", "null"] | None = None
     config_path: str = ".memoryhub.yaml"
     backend_class: str | None = None
 

--- a/packages/fipsagents/src/fipsagents/baseagent/memory.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/memory.py
@@ -12,6 +12,7 @@ The factory **never** raises — the agent always gets a usable client.
 
 Supported backends:
   - ``memoryhub``  — MemoryHub SDK (auto-detected or explicit)
+  - ``markdown``   — Human-readable markdown file(s) (via ``memory_markdown`` module)
   - ``sqlite``     — Local SQLite with FTS5 (via ``memory_sqlite`` module)
   - ``pgvector``   — PostgreSQL + pgvector (via ``memory_pgvector`` module)
   - ``custom``     — Any ``MemoryClientBase`` subclass at a dotted import path
@@ -233,6 +234,9 @@ async def create_memory_client(
     if backend == "memoryhub":
         return await _create_memoryhub_client(effective_path)
 
+    if backend == "markdown":
+        return await _create_markdown_client(effective_path)
+
     if backend == "sqlite":
         return await _create_sqlite_client(effective_path)
 
@@ -349,6 +353,20 @@ async def _create_pgvector_client(config_path: Path) -> MemoryClientBase:
             "PGVector memory backend requested but memory_pgvector module "
             "not found — falling back to NullMemoryClient. "
             "Install with: pip install fipsagents[pgvector]"
+        )
+        return NullMemoryClient()
+
+
+async def _create_markdown_client(config_path: Path) -> MemoryClientBase:
+    """Create a markdown-backed memory client."""
+    try:
+        from fipsagents.baseagent.memory_markdown import create_markdown_client
+
+        return await create_markdown_client(config_path)
+    except ImportError:
+        logger.error(
+            "Markdown memory backend requested but memory_markdown module "
+            "not found — falling back to NullMemoryClient"
         )
         return NullMemoryClient()
 

--- a/packages/fipsagents/src/fipsagents/baseagent/memory_markdown.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/memory_markdown.py
@@ -1,0 +1,381 @@
+"""Markdown memory backend.
+
+Human-readable, git-friendly memory for a single agent. Two modes,
+selected by the config file:
+
+- **Level 1 — single file.** One compound markdown document. Each memory
+  is a ``## <heading>`` section. The Karpathy LLM Wiki pattern.
+- **Level 2 — directory.** One ``.md`` file per topic. The filename (without
+  extension) is the memory id. Use when you have multiple functional areas
+  (standing instructions vs project memories) you want to curate separately.
+
+The primary use case is "I want my agent's memory to be a file I can read,
+edit, and commit to git." For search ranking, concurrent writes, or
+per-entry timestamps, use the sqlite backend.
+
+Design notes:
+
+- ``search(query="")`` returns every section/file in stable file order as
+  separate results. This is the recommended retrieval mode — agents should
+  load the entire memory once at session start and inject it as a stable
+  prefix, preserving prefix-cache hits across turns. Passing a non-empty
+  query does a case-insensitive substring filter; no ranking.
+- ``write`` appends. Memory IDs are section headings (Level 1) or filenames
+  (Level 2). If no ``memory_id`` kwarg is supplied, a timestamp is used
+  automatically. Caller is responsible for heading/filename uniqueness —
+  duplicate headings are allowed but ``update()`` only touches the first
+  match.
+- ``update`` rewrites the body of a section (Level 1) or the contents of a
+  file (Level 2) identified by ``memory_id``. Missing ids log a warning
+  and return ``None``.
+- ``report_contradiction`` is a log-only no-op; the human curates the file.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fipsagents.baseagent.memory import MemoryClientBase, NullMemoryClient
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+# Matches safe characters for Level-2 filenames. Rejects path separators,
+# whitespace, and anything that would complicate filesystem interaction.
+_SAFE_FILENAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _file_mtime_iso(path: Path) -> str | None:
+    try:
+        return datetime.fromtimestamp(
+            path.stat().st_mtime, tz=timezone.utc
+        ).isoformat(timespec="seconds")
+    except OSError:
+        return None
+
+
+def _parse_sections(text: str) -> list[tuple[str, str]]:
+    """Split a markdown doc into ``(heading, body)`` pairs.
+
+    Sections start at ``## <heading>`` lines at column 0. Anything before
+    the first such line is discarded. Body text is stripped of trailing
+    whitespace but inner blank lines are preserved.
+    """
+    parts = re.split(r"^## (.+?)\s*$", text, flags=re.MULTILINE)
+    # parts[0] is any content before the first heading — ignored.
+    # Subsequent entries alternate: heading, body, heading, body, ...
+    sections: list[tuple[str, str]] = []
+    for i in range(1, len(parts) - 1, 2):
+        heading = parts[i].strip()
+        body = parts[i + 1].strip("\n")
+        sections.append((heading, body))
+    return sections
+
+
+def _safe_filename(memory_id: str) -> str:
+    """Return *memory_id* if it's a safe flat filename, else raise."""
+    if not _SAFE_FILENAME_RE.match(memory_id):
+        raise ValueError(
+            f"Invalid memory_id for markdown filename: {memory_id!r}. "
+            "Use only letters, digits, '.', '_', and '-'."
+        )
+    return memory_id
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class MarkdownMemoryClient(MemoryClientBase):
+    """Markdown-backed memory — single file or directory of files.
+
+    Exactly one of *file* or *dir* must be provided. The other is ``None``.
+    """
+
+    def __init__(
+        self,
+        *,
+        file: Path | None = None,
+        dir: Path | None = None,
+    ) -> None:
+        if (file is None) == (dir is None):
+            raise ValueError(
+                "MarkdownMemoryClient requires exactly one of "
+                "`file` or `dir`."
+            )
+        self._file = file
+        self._dir = dir
+
+    # -- Search -------------------------------------------------------------
+
+    async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        try:
+            return await asyncio.to_thread(self._search_sync, query)
+        except Exception:
+            logger.warning(
+                "Markdown search failed for query %r", query, exc_info=True
+            )
+            return []
+
+    def _search_sync(self, query: str) -> list[dict[str, Any]]:
+        results = self._load_all()
+        if query:
+            needle = query.lower()
+            results = [r for r in results if needle in r["content"].lower()]
+        return results
+
+    def _load_all(self) -> list[dict[str, Any]]:
+        """Return every section/file in stable order.
+
+        For Level 1, parses the single markdown file into sections.
+        For Level 2, reads each ``*.md`` file in ``sorted()`` filename order
+        and returns one result per file.
+        """
+        if self._file is not None:
+            if not self._file.exists():
+                return []
+            text = self._file.read_text(encoding="utf-8")
+            updated_at = _file_mtime_iso(self._file)
+            return [
+                {
+                    "id": heading,
+                    "content": body,
+                    "created_at": None,
+                    "updated_at": updated_at,
+                }
+                for heading, body in _parse_sections(text)
+            ]
+
+        assert self._dir is not None
+        if not self._dir.exists():
+            return []
+        results: list[dict[str, Any]] = []
+        for path in sorted(self._dir.glob("*.md")):
+            try:
+                content = path.read_text(encoding="utf-8").strip("\n")
+            except OSError:
+                continue
+            results.append(
+                {
+                    "id": path.stem,
+                    "content": content,
+                    "created_at": None,
+                    "updated_at": _file_mtime_iso(path),
+                }
+            )
+        return results
+
+    # -- Write --------------------------------------------------------------
+
+    async def write(self, content: str, **kwargs: Any) -> dict[str, Any] | None:
+        memory_id = kwargs.get("memory_id")
+        try:
+            return await asyncio.to_thread(self._write_sync, content, memory_id)
+        except Exception:
+            logger.warning(
+                "Markdown write failed — memory not persisted", exc_info=True
+            )
+            return None
+
+    def _write_sync(
+        self, content: str, memory_id: str | None
+    ) -> dict[str, Any]:
+        if memory_id is None:
+            memory_id = _now_iso()
+
+        body = content.strip("\n")
+        created_at = _now_iso()
+
+        if self._file is not None:
+            # Level 1: append a new section. Ensure there's at least one
+            # blank line between the existing doc and the new section so
+            # the heading renders cleanly.
+            existing = (
+                self._file.read_text(encoding="utf-8") if self._file.exists() else ""
+            )
+            separator = "" if not existing or existing.endswith("\n\n") else (
+                "\n" if existing.endswith("\n") else "\n\n"
+            )
+            new_block = f"{separator}## {memory_id}\n\n{body}\n"
+            with self._file.open("a", encoding="utf-8") as f:
+                f.write(new_block)
+        else:
+            assert self._dir is not None
+            safe = _safe_filename(memory_id)
+            path = self._dir / f"{safe}.md"
+            path.write_text(f"{body}\n", encoding="utf-8")
+
+        return {
+            "id": memory_id,
+            "content": content,
+            "created_at": created_at,
+        }
+
+    # -- Update -------------------------------------------------------------
+
+    async def update(
+        self, memory_id: str, content: str, **kwargs: Any
+    ) -> dict[str, Any] | None:
+        try:
+            return await asyncio.to_thread(self._update_sync, memory_id, content)
+        except Exception:
+            logger.warning(
+                "Markdown update failed for memory %r — not persisted",
+                memory_id,
+                exc_info=True,
+            )
+            return None
+
+    def _update_sync(
+        self, memory_id: str, content: str
+    ) -> dict[str, Any] | None:
+        body = content.strip("\n")
+
+        if self._file is not None:
+            if not self._file.exists():
+                logger.warning(
+                    "Markdown update: file %s does not exist", self._file
+                )
+                return None
+            text = self._file.read_text(encoding="utf-8")
+            # Replace the first matching ``## <memory_id>`` block with a new
+            # body. The replacement covers from the heading line through
+            # (but not including) the next ``##`` heading, or end-of-file.
+            pattern = re.compile(
+                rf"(^## {re.escape(memory_id)}\s*\n)"
+                rf"(?:.*?)"
+                rf"(?=^## |\Z)",
+                re.MULTILINE | re.DOTALL,
+            )
+            new_text, n = pattern.subn(
+                lambda m: f"{m.group(1)}\n{body}\n\n", text, count=1
+            )
+            if n == 0:
+                logger.warning(
+                    "Markdown update: section %r not found in %s",
+                    memory_id, self._file,
+                )
+                return None
+            self._file.write_text(new_text, encoding="utf-8")
+        else:
+            assert self._dir is not None
+            try:
+                safe = _safe_filename(memory_id)
+            except ValueError:
+                logger.warning("Markdown update: invalid memory_id %r", memory_id)
+                return None
+            path = self._dir / f"{safe}.md"
+            if not path.exists():
+                logger.warning("Markdown update: file %s not found", path)
+                return None
+            path.write_text(f"{body}\n", encoding="utf-8")
+
+        return {
+            "id": memory_id,
+            "content": content,
+            "updated_at": _now_iso(),
+        }
+
+    # -- Contradictions -----------------------------------------------------
+
+    async def report_contradiction(
+        self, memory_id: str, description: str
+    ) -> None:
+        logger.warning(
+            "Contradiction reported for memory %r: %s "
+            "(markdown backend is human-curated; edit the file to resolve)",
+            memory_id, description,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+async def create_markdown_client(config_path: Path) -> MemoryClientBase:
+    """Build a ``MarkdownMemoryClient`` from ``.memory-markdown.yaml``.
+
+    Config schema (exactly one of ``file`` or ``dir`` required):
+
+    .. code-block:: yaml
+
+        # Level 1 — single compound doc
+        file: ./agent-memory.md
+
+    .. code-block:: yaml
+
+        # Level 2 — directory of topic files
+        dir: ./memories
+
+    Relative paths resolve against the config file's directory. Missing
+    files/directories are created empty. Returns ``NullMemoryClient`` on
+    any error so the agent always gets a usable client.
+    """
+    try:
+        import yaml
+
+        if not config_path.exists():
+            logger.debug(
+                "No markdown memory config at %s — memory integration disabled",
+                config_path,
+            )
+            return NullMemoryClient()
+
+        raw = config_path.read_text(encoding="utf-8")
+        cfg = yaml.safe_load(raw) or {}
+
+        file_raw = cfg.get("file")
+        dir_raw = cfg.get("dir")
+        if (file_raw is None) == (dir_raw is None):
+            logger.error(
+                "Markdown memory config %s must specify exactly one of "
+                "`file` or `dir` — falling back to NullMemoryClient",
+                config_path,
+            )
+            return NullMemoryClient()
+
+        base = config_path.parent
+        if file_raw is not None:
+            target = Path(file_raw)
+            if not target.is_absolute():
+                target = base / target
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if not target.exists():
+                target.touch()
+            logger.info(
+                "Markdown memory backend enabled (file: %s)", target
+            )
+            return MarkdownMemoryClient(file=target)
+
+        assert dir_raw is not None
+        target = Path(dir_raw)
+        if not target.is_absolute():
+            target = base / target
+        target.mkdir(parents=True, exist_ok=True)
+        logger.info("Markdown memory backend enabled (dir: %s)", target)
+        return MarkdownMemoryClient(dir=target)
+
+    except Exception:
+        logger.warning(
+            "Failed to initialise markdown memory backend from %s — "
+            "falling back to NullMemoryClient",
+            config_path,
+            exc_info=True,
+        )
+        return NullMemoryClient()

--- a/packages/fipsagents/tests/test_memory_markdown.py
+++ b/packages/fipsagents/tests/test_memory_markdown.py
@@ -1,0 +1,342 @@
+"""Tests for fipsagents.baseagent.memory_markdown — Level 1 + Level 2."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fipsagents.baseagent.config import MemoryConfig
+from fipsagents.baseagent.memory import NullMemoryClient, create_memory_client
+from fipsagents.baseagent.memory_markdown import (
+    MarkdownMemoryClient,
+    _parse_sections,
+    create_markdown_client,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_level1(tmp_path: Path) -> MarkdownMemoryClient:
+    cfg = tmp_path / ".memory-markdown.yaml"
+    cfg.write_text("file: memory.md\n")
+    client = await create_markdown_client(cfg)
+    assert isinstance(client, MarkdownMemoryClient)
+    return client
+
+
+async def _make_level2(tmp_path: Path) -> MarkdownMemoryClient:
+    cfg = tmp_path / ".memory-markdown.yaml"
+    cfg.write_text("dir: memories\n")
+    client = await create_markdown_client(cfg)
+    assert isinstance(client, MarkdownMemoryClient)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# TestParseSections
+# ---------------------------------------------------------------------------
+
+
+class TestParseSections:
+    def test_empty_string_returns_empty(self):
+        assert _parse_sections("") == []
+
+    def test_content_before_first_heading_is_ignored(self):
+        text = "preamble text\nmore preamble\n\n## first\n\nbody\n"
+        assert _parse_sections(text) == [("first", "body")]
+
+    def test_multiple_sections_preserve_order(self):
+        text = "## a\n\nbody a\n\n## b\n\nbody b\n"
+        assert _parse_sections(text) == [("a", "body a"), ("b", "body b")]
+
+    def test_body_with_blank_lines_preserved(self):
+        text = "## x\n\nline1\n\nline2\n\n## y\n\nbody y\n"
+        sections = _parse_sections(text)
+        assert sections[0] == ("x", "line1\n\nline2")
+
+    def test_heading_whitespace_stripped(self):
+        assert _parse_sections("## heading   \n\nbody\n") == [("heading", "body")]
+
+
+# ---------------------------------------------------------------------------
+# TestCreateMarkdownClient — factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMarkdownClient:
+    @pytest.mark.asyncio
+    async def test_level1_creates_client(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        assert client._file == tmp_path / "memory.md"
+        assert client._dir is None
+
+    @pytest.mark.asyncio
+    async def test_level2_creates_client(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        assert client._dir == tmp_path / "memories"
+        assert client._file is None
+
+    @pytest.mark.asyncio
+    async def test_level1_creates_file_if_missing(self, tmp_path):
+        await _make_level1(tmp_path)
+        assert (tmp_path / "memory.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_level2_creates_dir_if_missing(self, tmp_path):
+        await _make_level2(tmp_path)
+        assert (tmp_path / "memories").is_dir()
+
+    @pytest.mark.asyncio
+    async def test_missing_config_returns_null(self, tmp_path):
+        client = await create_markdown_client(tmp_path / "no-such-file.yaml")
+        assert isinstance(client, NullMemoryClient)
+
+    @pytest.mark.asyncio
+    async def test_malformed_config_returns_null(self, tmp_path):
+        cfg = tmp_path / ".memory-markdown.yaml"
+        cfg.write_text("[[[not valid yaml")
+        client = await create_markdown_client(cfg)
+        assert isinstance(client, NullMemoryClient)
+
+    @pytest.mark.asyncio
+    async def test_both_file_and_dir_returns_null(self, tmp_path):
+        cfg = tmp_path / ".memory-markdown.yaml"
+        cfg.write_text("file: a.md\ndir: b/\n")
+        client = await create_markdown_client(cfg)
+        assert isinstance(client, NullMemoryClient)
+
+    @pytest.mark.asyncio
+    async def test_neither_file_nor_dir_returns_null(self, tmp_path):
+        cfg = tmp_path / ".memory-markdown.yaml"
+        cfg.write_text("# no keys\n")
+        client = await create_markdown_client(cfg)
+        assert isinstance(client, NullMemoryClient)
+
+    @pytest.mark.asyncio
+    async def test_relative_paths_resolved_from_config_dir(self, tmp_path):
+        subdir = tmp_path / "configs"
+        subdir.mkdir()
+        cfg = subdir / ".memory-markdown.yaml"
+        cfg.write_text("file: ../notes.md\n")
+        client = await create_markdown_client(cfg)
+        assert isinstance(client, MarkdownMemoryClient)
+        assert (tmp_path / "notes.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# TestLevel1Write
+# ---------------------------------------------------------------------------
+
+
+class TestLevel1Write:
+    @pytest.mark.asyncio
+    async def test_write_appends_section(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("content here", memory_id="topic-a")
+        text = (tmp_path / "memory.md").read_text()
+        assert "## topic-a" in text
+        assert "content here" in text
+
+    @pytest.mark.asyncio
+    async def test_write_returns_dict_with_id_and_content(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        result = await client.write("hello", memory_id="greeting")
+        assert result["id"] == "greeting"
+        assert result["content"] == "hello"
+        assert "created_at" in result
+
+    @pytest.mark.asyncio
+    async def test_write_without_memory_id_uses_timestamp(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        result = await client.write("auto-headed")
+        # Timestamp headings start with a year: 20XX-...
+        assert result["id"].startswith("20")
+        text = (tmp_path / "memory.md").read_text()
+        assert f"## {result['id']}" in text
+
+    @pytest.mark.asyncio
+    async def test_write_multiple_preserves_order(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("first body", memory_id="first")
+        await client.write("second body", memory_id="second")
+        text = (tmp_path / "memory.md").read_text()
+        assert text.index("## first") < text.index("## second")
+
+
+# ---------------------------------------------------------------------------
+# TestLevel1Search
+# ---------------------------------------------------------------------------
+
+
+class TestLevel1Search:
+    @pytest.mark.asyncio
+    async def test_search_empty_query_returns_every_section(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("body a", memory_id="a")
+        await client.write("body b", memory_id="b")
+        results = await client.search("")
+        assert [r["id"] for r in results] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query_preserves_file_order(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        for heading in ["first", "second", "third"]:
+            await client.write(f"body {heading}", memory_id=heading)
+        results = await client.search("")
+        assert [r["id"] for r in results] == ["first", "second", "third"]
+
+    @pytest.mark.asyncio
+    async def test_search_substring_matches_case_insensitively(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("the user's favorite color is teal", memory_id="colors")
+        await client.write("the user's cat is named Mochi", memory_id="pets")
+        results = await client.search("TEAL")
+        assert [r["id"] for r in results] == ["colors"]
+
+    @pytest.mark.asyncio
+    async def test_search_no_match_returns_empty(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("body", memory_id="entry")
+        results = await client.search("nothing-here")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_on_empty_file_returns_empty(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        assert await client.search("") == []
+        assert await client.search("anything") == []
+
+
+# ---------------------------------------------------------------------------
+# TestLevel1Update
+# ---------------------------------------------------------------------------
+
+
+class TestLevel1Update:
+    @pytest.mark.asyncio
+    async def test_update_replaces_section_body(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("original body", memory_id="topic")
+        result = await client.update("topic", "new body")
+        assert result is not None
+        assert result["content"] == "new body"
+        results = await client.search("")
+        assert results[0]["content"] == "new body"
+
+    @pytest.mark.asyncio
+    async def test_update_preserves_other_sections(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("body a", memory_id="a")
+        await client.write("body b", memory_id="b")
+        await client.update("a", "body a updated")
+        ids = [r["id"] for r in await client.search("")]
+        assert ids == ["a", "b"]
+        a_result = await client.search("updated")
+        assert len(a_result) == 1
+        assert a_result[0]["id"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_section_returns_none(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        await client.write("body", memory_id="exists")
+        result = await client.update("does-not-exist", "new")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_on_missing_file_returns_none(self, tmp_path):
+        client = await _make_level1(tmp_path)
+        (tmp_path / "memory.md").unlink()
+        result = await client.update("anything", "content")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestLevel2Write / Search / Update
+# ---------------------------------------------------------------------------
+
+
+class TestLevel2:
+    @pytest.mark.asyncio
+    async def test_write_creates_file_named_after_memory_id(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        await client.write("body content", memory_id="preferences")
+        assert (tmp_path / "memories" / "preferences.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_write_rejects_unsafe_filename(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        result = await client.write("body", memory_id="../evil")
+        # Write catches ValueError from _safe_filename and returns None.
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_search_returns_one_result_per_file(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        await client.write("body alpha", memory_id="alpha")
+        await client.write("body beta", memory_id="beta")
+        results = await client.search("")
+        assert [r["id"] for r in results] == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_search_filters_by_substring(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        await client.write("the user likes teal", memory_id="colors")
+        await client.write("cat is mochi", memory_id="pets")
+        results = await client.search("mochi")
+        assert [r["id"] for r in results] == ["pets"]
+
+    @pytest.mark.asyncio
+    async def test_update_rewrites_file(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        await client.write("original", memory_id="topic")
+        await client.update("topic", "replacement")
+        assert (tmp_path / "memories" / "topic.md").read_text().strip() == "replacement"
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_file_returns_none(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        assert await client.update("missing", "content") is None
+
+    @pytest.mark.asyncio
+    async def test_sort_order_stable_across_writes(self, tmp_path):
+        client = await _make_level2(tmp_path)
+        # Deliberately out-of-alphabetical write order.
+        await client.write("c", memory_id="charlie")
+        await client.write("a", memory_id="alpha")
+        await client.write("b", memory_id="bravo")
+        results = await client.search("")
+        assert [r["id"] for r in results] == ["alpha", "bravo", "charlie"]
+
+
+# ---------------------------------------------------------------------------
+# TestContradiction
+# ---------------------------------------------------------------------------
+
+
+class TestContradiction:
+    @pytest.mark.asyncio
+    async def test_report_contradiction_is_noop_and_logs(self, tmp_path, caplog):
+        client = await _make_level1(tmp_path)
+        import logging
+        with caplog.at_level(logging.WARNING):
+            await client.report_contradiction("id", "desc")
+        assert any("Contradiction reported" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# TestDispatcherIntegration — entering via create_memory_client
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherIntegration:
+    @pytest.mark.asyncio
+    async def test_markdown_backend_via_memory_config(self, tmp_path):
+        cfg_file = tmp_path / ".memory-markdown.yaml"
+        cfg_file.write_text("file: memory.md\n")
+        mc = MemoryConfig(backend="markdown", config_path=str(cfg_file))
+        client = await create_memory_client(config=mc)
+        assert isinstance(client, MarkdownMemoryClient)


### PR DESCRIPTION
Addresses #44 Phase A.

Fills the Level-1 / Level-2 gap in the memory backend lineup — a human-readable, git-committed memory store for agents whose memory a developer wants to eyeball and edit by hand.

## Design summary

Two modes selected by config:

- **Level 1** (`file: ./memory.md`) — one compound markdown doc, each memory is a `## <heading>` section. The Karpathy LLM Wiki pattern.
- **Level 2** (`dir: ./memories`) — one `.md` file per topic, filename (without extension) is the memory id. Use when you have multiple functional areas to curate separately (e.g. standing instructions vs project memories).

Same backend, same code, the config picks which mode.

Memory IDs = section headings (Level 1) or filename stems (Level 2). The LLM can both append (`write`) and edit (`update`) using human-readable addresses rather than opaque UUIDs.

`search(query="")` returns every section/file in stable file order, intentionally designed for cache-friendly injection: agents load the whole memory set once at session start and inject it as a stable prefix so token positions don't shift between turns. Non-empty queries do a case-insensitive substring filter without ranking — no index, no magic. If you need ranked retrieval, jump to the sqlite backend.

`report_contradiction` is a log-only no-op; the human edits the file to resolve.

## Positioning vs other backends

Added a decision tree to `docs/architecture.md` Memory Integration section:

```
Does this agent need memory across sessions?
├─ No  → backend: null
└─ Yes → How will you curate it?
   ├─ I'll read and edit the file by hand, commit it to git
   │  ├─ One topic       → markdown, file: ./memory.md    (Level 1)
   │  └─ Multiple areas  → markdown, dir:  ./memories      (Level 2)
   ├─ Agent needs searchable memory on one host → sqlite   (Level 3)
   ├─ Multiple agents share memory / vector     → pgvector (Level 4)
   └─ Audit trails, RBAC, retention             → memoryhub (Level 5)
```

Each jump is a real jump, not a sliding scale of features. Users should recognise themselves in exactly one row.

## What this PR deliberately does NOT build

- No search ranking beyond file order (use sqlite)
- No regex (use sqlite)
- No per-section frontmatter/metadata (it's sqlite in a costume)
- No multi-level directory trees (flat dir only)
- No auto-injection into BaseAgent.build_system_prompt — that belongs in the separate memory-prefix-slot follow-up ([#47](https://github.com/redhat-ai-americas/agent-template/issues/47)) because it applies to all backends, not just markdown

## Scope-discipline check

Single-file module, no new runtime deps (pyyaml already present), pattern mirrors `memory_sqlite.py` / `memory_pgvector.py` exactly. The `custom` backend remains the escape hatch.

## Test plan

- [x] 36 new tests in `test_memory_markdown.py` — factory (both modes, missing/malformed/both-keys/neither-key configs, relative paths), Level 1 write/search/update, Level 2 write/search/update/unsafe-filename rejection, stable sort order, dispatcher integration
- [x] Full `fipsagents` suite 429/429 green (393 previously + 36 new)
- [x] gitleaks clean

## Follow-ups

- [#47](https://github.com/redhat-ai-americas/agent-template/issues/47) — BaseAgent first-class stable memory-prefix slot so the cache-friendly injection pattern works across all backends
- #44 Phase B (LlamaStack memory backend) — unchanged plan; can proceed whenever the LlamaStack endpoint from #42 is the right starting point