### PR TITLE
chore: Add CODEOWNERS and branch protection for main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code Owners - all PRs require approval from @rdwj
+*       @rdwj


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` assigning @rdwj as code owner for all files
- Branch protection rules already applied via API: PR reviews, CODEOWNERS approval, linear history, conversation resolution required

## Test plan

- [x] Branch protection rules verified via GitHub API
- [ ] Merge this PR to activate CODEOWNERS enforcement