### PR TITLE
feat: Scaffold feedback configuration in new agent projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@ All notable changes to the `fipsagents` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.12.0] - 2026-04-27
 
 ### Added
 
 - **User feedback collection** — `POST/GET /v1/feedback`, `GET /v1/feedback/stats` with pluggable `FeedbackStore` backends (null, sqlite, postgres). Records ratings (thumbs-up/-down), comments, corrections, and aggregated stats.
 - **In-place feedback updates** — `PATCH /v1/feedback/{feedback_id}` mutates an existing record (rating change, comment edit) rather than accumulating duplicates. Backed by a new `update()` method on the `FeedbackStore` ABC; partial payloads (None means "leave unchanged"). Returns 404 if the id is unknown, 200 with the updated record otherwise.
 - **Trace ID surfacing** — every chat completion response now carries an `X-Trace-Id` header (sync and streaming) and the final SSE usage chunk includes a top-level `trace_id` field. Lets clients correlate completions with traces and submit feedback against a known trace.
+- **Identity attribution on feedback** — `FeedbackRecord` gains a `user_id` field (default `"anonymous"`) populated from the gateway-issued `X-Auth-Subject` header (gateway-template#21 v1). Both SQLite and Postgres carry idempotent `ADD COLUMN` migrations so pre-cutover databases survive without downtime; legacy rows surface as `"anonymous"`. New `user_id` query filter on `GET /v1/feedback`.
+- **Scaffolded feedback config** — `fips-agents create agent` now writes a `feedback:` block in `agent.yaml` and a `[feedback]` extra hint, so new projects pick up the feature without manual wiring.
+- **Local smoke test** — `scripts/smoke-feedback.sh` exercises the full ui → gateway → agent stack offline (no LLM required, ~30 checks). Asserts the gateway strips spoofed `X-Auth-Subject` headers in anonymous mode.
 
 ### Changed
 

--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fipsagents"
-version = "0.11.0"
+version = "0.12.0"
 description = "Production-ready AI agent framework for FIPS/OpenShift environments"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -55,6 +55,10 @@ otel = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.20",
     "opentelemetry-api>=1.20",
 ]
+feedback = [
+    "aiosqlite>=0.20.0",
+    "asyncpg>=0.29.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",

--- a/templates/agent-loop/agent.yaml
+++ b/templates/agent-loop/agent.yaml
@@ -204,6 +204,27 @@ server:
   metrics:
     enabled: ${METRICS_ENABLED:-false}
 
+  # -- User feedback collection (optional) --------------------------------------
+  #
+  # Persists thumbs-up / thumbs-down ratings, comments, and corrections
+  # submitted via the UI.  Records are joined to traces (when tracing is
+  # enabled) so feedback can be correlated with the conversation that
+  # produced it.
+  #
+  # Requires a storage backend (sqlite or postgres) for persistence —
+  # without one, feedback POSTs are accepted and discarded.
+  #
+  # REST endpoints:
+  #   POST /v1/feedback            -- submit a rating
+  #   GET  /v1/feedback            -- query records (filter by trace/session)
+  #   GET  /v1/feedback/stats      -- aggregated counts grouped by window
+  #
+  # Production env vars:
+  #   FEEDBACK_ENABLED  -- "true" to enable
+  feedback:
+    enabled: ${FEEDBACK_ENABLED:-false}
+    max_age_hours: 720           # feedback expires after 30 days
+
 # -- Memory backend (optional) -----------------------------------------------
 #
 # Controls which memory backend the agent uses.

--- a/templates/agent-loop/pyproject.toml
+++ b/templates/agent-loop/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+feedback = [
+    "fipsagents[feedback]",
+]
 memory = [
     "fipsagents[memory]",
 ]


### PR DESCRIPTION
## Summary

Adds the user-feedback knobs to the scaffold the CLI clones when running \`fips-agents create agent <name>\`:

- **\`templates/agent-loop/agent.yaml\`** — new \`feedback:\` block under \`server:\`, mirroring the sessions/traces/metrics pattern. Disabled by default, single \`FEEDBACK_ENABLED\` env var, 720-hour housekeeping window.
- **\`templates/agent-loop/pyproject.toml\`** — new \`feedback = ["fipsagents[feedback]"]\` extra, mirroring the \`memory = [...]\` pattern.
- **\`packages/fipsagents/pyproject.toml\`** — new \`feedback\` extra (\`aiosqlite\`, \`asyncpg\`) so the scaffolded reference resolves.

The workflow template intentionally has no \`server:\` section, so it gets no feedback block.

Closes fips-agents/fips-agents-cli#18. The fips-agents-cli itself needs no code changes — it scaffolds whatever lives in this repo. Companion to #109 (FeedbackStore implementation) and #110 (trace_id surfacing).

## Test plan

- [x] \`yaml.safe_load(agent.yaml)\` parses; \`server.feedback\` block is well-formed
- [x] \`tomllib.load(pyproject.toml)\` parses; both extras resolve
- [x] \`pytest packages/fipsagents/tests/\` — 619 passed, 20 skipped (no behavioural change)
- [ ] End-to-end: \`fips-agents create agent demo\` produces a project whose \`agent.yaml\` includes the new block (verifiable once #109 and #110 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)