### PR TITLE
feat: Surface trace_id to chat completion clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 
 - **User feedback collection** — `POST/GET /v1/feedback`, `GET /v1/feedback/stats` with pluggable `FeedbackStore` backends (null, sqlite, postgres). Records ratings (thumbs-up/-down), comments, corrections, and aggregated stats.
+- **In-place feedback updates** — `PATCH /v1/feedback/{feedback_id}` mutates an existing record (rating change, comment edit) rather than accumulating duplicates. Backed by a new `update()` method on the `FeedbackStore` ABC; partial payloads (None means "leave unchanged"). Returns 404 if the id is unknown, 200 with the updated record otherwise.
 - **Trace ID surfacing** — every chat completion response now carries an `X-Trace-Id` header (sync and streaming) and the final SSE usage chunk includes a top-level `trace_id` field. Lets clients correlate completions with traces and submit feedback against a known trace.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the `fipsagents` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **User feedback collection** — `POST/GET /v1/feedback`, `GET /v1/feedback/stats` with pluggable `FeedbackStore` backends (null, sqlite, postgres). Records ratings (thumbs-up/-down), comments, corrections, and aggregated stats.
+- **Trace ID surfacing** — every chat completion response now carries an `X-Trace-Id` header (sync and streaming) and the final SSE usage chunk includes a top-level `trace_id` field. Lets clients correlate completions with traces and submit feedback against a known trace.
+
+### Changed
+
+- `CreateFeedbackRequest.trace_id` is now optional. When omitted the server synthesises a stand-alone identifier, so feedback works even if tracing is disabled or sampled out (orphan records are still stored).
+
 ## [0.11.0] - 2026-04-25
 
 ### Added

--- a/packages/fipsagents/src/fipsagents/serialization/openai_sse.py
+++ b/packages/fipsagents/src/fipsagents/serialization/openai_sse.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import json
 import time
 import uuid
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 from fipsagents.baseagent.events import (
     ContentDelta,
@@ -78,6 +78,7 @@ def _usage_chunk(
     completion_id: str,
     model_name: str,
     metrics: StreamMetrics,
+    trace_id: str | None = None,
 ) -> str:
     """Serialize a final usage chunk (OpenAI ``include_usage`` convention).
 
@@ -86,8 +87,12 @@ def _usage_chunk(
     object. We also attach a ``stream_metrics`` extension carrying
     TTFT / ITL / counters that OpenAI's spec does not cover; unknown
     fields are ignored by conforming clients.
+
+    When ``trace_id`` is provided it is included as a top-level field so
+    clients can correlate this completion with a stored trace (e.g. to
+    attach feedback via ``POST /v1/feedback``).
     """
-    chunk = {
+    chunk: dict[str, Any] = {
         "id": completion_id,
         "object": "chat.completion.chunk",
         "created": _now(),
@@ -107,6 +112,8 @@ def _usage_chunk(
             "tool_calls": metrics.tool_calls,
         },
     }
+    if trace_id is not None:
+        chunk["trace_id"] = trace_id
     return f"data: {json.dumps(chunk)}\n\n"
 
 
@@ -119,6 +126,7 @@ async def stream_events_as_sse(
     events: AsyncIterator[StreamEvent],
     model_name: str,
     completion_id: str | None = None,
+    trace_id: str | None = None,
 ) -> AsyncIterator[str]:
     """Translate a ``StreamEvent`` sequence into OpenAI SSE chunks.
 
@@ -128,6 +136,9 @@ async def stream_events_as_sse(
         model_name: Model identifier echoed in every chunk's ``model`` field.
         completion_id: Optional completion ID. When ``None`` an ID of the form
             ``chatcmpl-<24 hex chars>`` is generated automatically.
+        trace_id: Optional trace identifier. When provided it is attached to
+            the final usage chunk so clients can correlate the completion
+            with a stored trace (e.g. for feedback submission).
 
     Yields:
         SSE-encoded strings (``data: {...}\\n\\n`` or ``data: [DONE]\\n\\n``).
@@ -224,7 +235,9 @@ async def stream_events_as_sse(
                 )
                 # OpenAI's stream_options.include_usage appends a
                 # separate chunk with empty choices carrying usage.
-                yield _usage_chunk(completion_id, model_name, event.metrics)
+                yield _usage_chunk(
+                    completion_id, model_name, event.metrics, trace_id=trace_id,
+                )
 
     except Exception as exc:
         err = {"error": {"message": str(exc), "type": type(exc).__name__}}

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -6,9 +6,15 @@ import asyncio
 import logging
 import random
 import re
+import uuid
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator
+
+
+def _new_trace_id() -> str:
+    """Generate a trace identifier matching ``TraceCollector``'s format."""
+    return f"trace_{uuid.uuid4().hex[:16]}"
 
 try:
     from fastapi import Body, FastAPI, HTTPException, Request
@@ -339,7 +345,7 @@ class OpenAIChatServer:
         user_id = request.headers.get("X-Auth-Subject", "anonymous")
         record = FeedbackRecord(
             feedback_id=_generate_feedback_id(),
-            trace_id=body.trace_id,
+            trace_id=body.trace_id or _new_trace_id(),
             session_id=body.session_id,
             rating=body.rating,
             comment=body.comment,
@@ -460,17 +466,23 @@ class OpenAIChatServer:
             else:
                 logger.info("Session %s not found; will auto-create on save", req.session_id)
 
+        # Trace ID: always generated so clients can correlate this
+        # completion with feedback/observability data, even when tracing
+        # persistence is disabled or sampled out. If a parent trace
+        # context is propagated, use that trace_id so we join the
+        # distributed trace.
+        from .propagation import extract_trace_context
+        parent_ctx = extract_trace_context(request.headers)
+        trace_id = (parent_ctx.trace_id if parent_ctx else None) or _new_trace_id()
+
         # Tracing: create collector if sampling says yes.
         collector: TraceCollector | None = None
         if self._should_trace():
-            from .propagation import extract_trace_context
-            parent_ctx = extract_trace_context(request.headers)
-
             collector = TraceCollector(
                 self._trace_store,
+                trace_id=trace_id,
                 session_id=req.session_id,
                 model=model_name,
-                parent_trace_id=parent_ctx.trace_id if parent_ctx else None,
                 parent_span_id=parent_ctx.parent_span_id if parent_ctx else None,
             )
             collector.begin_request({
@@ -504,20 +516,22 @@ class OpenAIChatServer:
                     content,
                     metrics=metrics,
                     finish_reason=finish_reason,
-                )
+                ),
+                headers={"X-Trace-Id": trace_id},
             )
 
         return StreamingResponse(
             self._stream(
                 incoming, model_name, overrides=overrides,
                 session_id=req.session_id, collector=collector,
-                metrics_start=metrics_start,
+                metrics_start=metrics_start, trace_id=trace_id,
             ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
                 "X-Accel-Buffering": "no",
+                "X-Trace-Id": trace_id,
             },
         )
 
@@ -595,6 +609,7 @@ class OpenAIChatServer:
         session_id: str | None = None,
         collector: TraceCollector | None = None,
         metrics_start: float | None = None,
+        trace_id: str | None = None,
     ) -> AsyncIterator[str]:
         """Drive the agent's event stream, serialising to OpenAI SSE chunks.
 
@@ -616,7 +631,9 @@ class OpenAIChatServer:
                     )
                 if collector:
                     events = collector.observe(events)
-                async for chunk in stream_events_as_sse(events, model_name):
+                async for chunk in stream_events_as_sse(
+                    events, model_name, trace_id=trace_id,
+                ):
                     yield chunk
             except Exception:
                 logger.exception("Stream errored")

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -24,11 +24,6 @@ from fipsagents.baseagent import BaseAgent
 from fipsagents.baseagent.events import ContentDelta, StreamComplete, StreamMetrics
 from fipsagents.serialization.openai_sse import stream_events_as_sse
 
-
-def _new_trace_id() -> str:
-    """Generate a trace identifier matching ``TraceCollector``'s format."""
-    return f"trace_{uuid.uuid4().hex[:16]}"
-
 from .models import (
     ChatCompletionRequest,
     CreateFeedbackRequest,
@@ -51,6 +46,11 @@ from .feedback import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _new_trace_id() -> str:
+    """Generate a trace identifier matching ``TraceCollector``'s format."""
+    return f"trace_{uuid.uuid4().hex[:16]}"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -11,11 +11,6 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator
 
-
-def _new_trace_id() -> str:
-    """Generate a trace identifier matching ``TraceCollector``'s format."""
-    return f"trace_{uuid.uuid4().hex[:16]}"
-
 try:
     from fastapi import Body, FastAPI, HTTPException, Request
     from fastapi.responses import JSONResponse, StreamingResponse
@@ -28,6 +23,11 @@ except ImportError as exc:  # pragma: no cover — helpful error path
 from fipsagents.baseagent import BaseAgent
 from fipsagents.baseagent.events import ContentDelta, StreamComplete, StreamMetrics
 from fipsagents.serialization.openai_sse import stream_events_as_sse
+
+
+def _new_trace_id() -> str:
+    """Generate a trace identifier matching ``TraceCollector``'s format."""
+    return f"trace_{uuid.uuid4().hex[:16]}"
 
 from .models import (
     ChatCompletionRequest,

--- a/packages/fipsagents/src/fipsagents/server/models.py
+++ b/packages/fipsagents/src/fipsagents/server/models.py
@@ -78,10 +78,19 @@ class ChatCompletionRequest(BaseModel):
 
 
 class CreateFeedbackRequest(BaseModel):
-    """Request body for POST /v1/feedback."""
+    """Request body for POST /v1/feedback.
 
-    trace_id: str
+    ``trace_id`` is optional: clients normally send the value they
+    received from the chat completion (in the ``X-Trace-Id`` response
+    header or the final ``trace_id`` field of the SSE usage chunk), but
+    when tracing is sampled out or the caller does not have one the
+    server synthesises a stand-alone identifier. Records keyed to a
+    real trace can be joined to the trace store; orphan records
+    cannot but are still useful as raw rating data.
+    """
+
     rating: int
+    trace_id: str | None = None
     session_id: str | None = None
     comment: str | None = None
     correction: str | None = None

--- a/packages/fipsagents/tests/test_serialization_openai_sse.py
+++ b/packages/fipsagents/tests/test_serialization_openai_sse.py
@@ -238,3 +238,45 @@ async def test_model_name_included_in_every_chunk():
     )
     chunks = [f for f in frames if f != "[DONE]"]
     assert all(f["model"] == "granite-8b" for f in chunks)
+
+
+async def test_trace_id_included_on_usage_chunk_when_provided():
+    events = [
+        ContentDelta(content="x"),
+        StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
+    ]
+    frames = await _collect(
+        stream_events_as_sse(_iter(events), model_name="m", trace_id="trace_abc123")
+    )
+    usage_chunks = [
+        f for f in frames if isinstance(f, dict) and f.get("choices") == []
+    ]
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0]["trace_id"] == "trace_abc123"
+
+
+async def test_trace_id_omitted_when_not_provided():
+    events = [StreamComplete(finish_reason="stop", metrics=StreamMetrics())]
+    frames = await _collect(stream_events_as_sse(_iter(events), model_name="m"))
+    usage_chunks = [
+        f for f in frames if isinstance(f, dict) and f.get("choices") == []
+    ]
+    assert len(usage_chunks) == 1
+    assert "trace_id" not in usage_chunks[0]
+
+
+async def test_trace_id_not_on_per_token_chunks():
+    """Only the final usage chunk carries trace_id; deltas stay clean."""
+    events = [
+        ContentDelta(content="x"),
+        ContentDelta(content="y"),
+        StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
+    ]
+    frames = await _collect(
+        stream_events_as_sse(_iter(events), model_name="m", trace_id="trace_xyz")
+    )
+    delta_chunks = [
+        f for f in frames if isinstance(f, dict) and f.get("choices")
+    ]
+    for chunk in delta_chunks:
+        assert "trace_id" not in chunk

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import types
 from typing import AsyncIterator
 
@@ -759,10 +760,7 @@ def test_agent_info_includes_llm_tools():
 # ---------------------------------------------------------------------------
 
 
-import re as _re
-
-
-_TRACE_ID_RE = _re.compile(r"^trace_[0-9a-f]{16}$")
+_TRACE_ID_RE = re.compile(r"^trace_[0-9a-f]{16}$")
 
 
 def test_sync_response_includes_x_trace_id_header():

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -752,3 +752,99 @@ def test_agent_info_includes_llm_tools():
     assert body["tools"][0]["name"] == "search"
     assert body["tools"][0]["description"] == "Search the web"
     assert body["tools"][0]["parameters"]["properties"]["q"]["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# X-Trace-Id surfacing
+# ---------------------------------------------------------------------------
+
+
+import re as _re
+
+
+_TRACE_ID_RE = _re.compile(r"^trace_[0-9a-f]{16}$")
+
+
+def test_sync_response_includes_x_trace_id_header():
+    events = [
+        ContentDelta(content="ok"),
+        StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
+    ]
+    server = _build_server(events)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+        )
+    assert resp.status_code == 200
+    trace_id = resp.headers.get("x-trace-id")
+    assert trace_id is not None
+    assert _TRACE_ID_RE.match(trace_id), f"Bad trace_id format: {trace_id!r}"
+
+
+def test_streaming_response_includes_x_trace_id_header_and_chunk_field():
+    events = [
+        ContentDelta(content="hi"),
+        StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
+    ]
+    server = _build_server(events)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "ping"}],
+                "stream": True,
+            },
+        )
+    header_trace_id = resp.headers.get("x-trace-id")
+    assert header_trace_id is not None
+    assert _TRACE_ID_RE.match(header_trace_id)
+
+    frames = _parse_sse_body(resp.text)
+    usage_chunks = [
+        f for f in frames if isinstance(f, dict) and f.get("choices") == []
+    ]
+    assert len(usage_chunks) == 1
+    assert usage_chunks[0]["trace_id"] == header_trace_id
+
+
+def test_x_trace_id_uses_propagated_parent_when_provided():
+    """If a W3C traceparent header is sent, the trace_id surfaces from it."""
+    events = [
+        ContentDelta(content="ok"),
+        StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
+    ]
+    server = _build_server(events)
+    parent_trace_hex = "0123456789abcdef0123456789abcdef"
+    traceparent = f"00-{parent_trace_hex}-0123456789abcdef-01"
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+            headers={"traceparent": traceparent},
+        )
+    assert resp.status_code == 200
+    assert resp.headers.get("x-trace-id") == parent_trace_hex
+
+
+def test_create_feedback_accepts_request_without_trace_id():
+    """trace_id is optional; server synthesises one when absent."""
+    from fipsagents.server.models import CreateFeedbackRequest
+
+    req = CreateFeedbackRequest(rating=1)
+    assert req.trace_id is None
+    assert req.rating == 1
+
+
+def test_create_feedback_rejects_invalid_rating():
+    from fipsagents.server.models import CreateFeedbackRequest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CreateFeedbackRequest(rating=0)

--- a/scripts/run-stack-anthropic.sh
+++ b/scripts/run-stack-anthropic.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# Bring up the full feedback-track stack pointed at the Anthropic API
+# via the llm-adapter sidecar, and leave everything running for manual
+# browser testing.
+#
+# Layout:
+#
+#   browser
+#      │
+#      ▼
+#   ui-template        :13000  (static + /v1 reverse proxy)
+#      │
+#      ▼
+#   gateway-template   :18090  (chat + feedback pass-through)
+#      │
+#      ▼
+#   agent (real Claude Haiku, sqlite feedback store, tracing on)
+#                      :18080
+#      │
+#      ▼
+#   llm-adapter        :18081  (OpenAI → Anthropic translator)
+#      │
+#      ▼
+#   api.anthropic.com
+#
+# Usage:
+#   scripts/run-stack-anthropic.sh
+#   scripts/run-stack-anthropic.sh --stop      # kill anything left running
+#   MODEL=claude-haiku-4-5 scripts/run-stack-anthropic.sh
+#
+# Reads ANTHROPIC_API_KEY from $HOME/.secrets (sourced shell file).
+# Ctrl-C to stop, or run again with --stop.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATEWAY_REPO="${GATEWAY_REPO:-$HOME/Developer/AGENTS/gateway-template}"
+UI_REPO="${UI_REPO:-$HOME/Developer/AGENTS/ui-template}"
+ADAPTER_DIR="${ADAPTER_DIR:-$REPO_ROOT/packages/llm-adapter}"
+
+# BaseAgent hardcodes the adapter sidecar at http://localhost:8081/v1
+# (fipsagents.baseagent.config._ADAPTER_PORT). Stick to that port to
+# match the production wiring; the runner monkey-patches it if you set
+# ADAPTER_PORT to something else.
+ADAPTER_PORT="${ADAPTER_PORT:-8081}"
+AGENT_PORT="${AGENT_PORT:-18080}"
+GATEWAY_PORT="${GATEWAY_PORT:-18090}"
+UI_PORT="${UI_PORT:-13000}"
+
+MODEL="${MODEL:-claude-haiku-4-5}"
+
+PIDFILE="${TMPDIR:-/tmp}/fipsagents-stack.pids"
+
+c_red()   { printf '\033[31m%s\033[0m' "$1"; }
+c_green() { printf '\033[32m%s\033[0m' "$1"; }
+c_dim()   { printf '\033[2m%s\033[0m' "$1"; }
+say()     { echo "$(c_dim '==>') $1"; }
+ok()      { echo "  $(c_green ok) $1"; }
+die()     { echo "  $(c_red ERR) $1" >&2; exit 1; }
+
+# ---- --stop subcommand -----------------------------------------------------
+
+if [ "${1:-}" = "--stop" ]; then
+  if [ ! -f "$PIDFILE" ]; then
+    say "no $PIDFILE; nothing to stop"
+    exit 0
+  fi
+  while read -r pid name; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null && ok "killed $name pid=$pid" || true
+    fi
+  done <"$PIDFILE"
+  rm -f "$PIDFILE"
+  exit 0
+fi
+
+# Refuse to start if a previous run is still up.
+if [ -f "$PIDFILE" ] && grep -q '[0-9]' "$PIDFILE"; then
+  while read -r pid _; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      die "previous run still alive (pid $pid). Run \`$0 --stop\` first."
+    fi
+  done <"$PIDFILE"
+fi
+: >"$PIDFILE"
+record_pid() { echo "$1 $2" >>"$PIDFILE"; }
+
+# ---- prereqs ---------------------------------------------------------------
+
+say "Checking prerequisites"
+for cmd in python3 go curl jq; do
+  command -v "$cmd" >/dev/null 2>&1 || die "$cmd not in PATH"
+done
+[ -d "$GATEWAY_REPO" ] || die "GATEWAY_REPO not found: $GATEWAY_REPO"
+[ -d "$UI_REPO" ]      || die "UI_REPO not found: $UI_REPO"
+[ -d "$ADAPTER_DIR" ]  || die "ADAPTER_DIR not found: $ADAPTER_DIR"
+[ -f "$HOME/.secrets" ] || die "$HOME/.secrets not found"
+
+# ---- secrets ---------------------------------------------------------------
+
+# shellcheck disable=SC1090
+. "$HOME/.secrets"
+[ -n "${ANTHROPIC_API_KEY:-}" ] || die "ANTHROPIC_API_KEY missing after sourcing ~/.secrets"
+ok "ANTHROPIC_API_KEY loaded (${#ANTHROPIC_API_KEY} chars)"
+
+# ---- workdir + venv --------------------------------------------------------
+
+WORKDIR="$REPO_ROOT/.local/stack"
+mkdir -p "$WORKDIR/agent/prompts" "$WORKDIR/agent/tools" "$WORKDIR/logs"
+say "workdir: $WORKDIR"
+
+if [ ! -d "$WORKDIR/.venv" ]; then
+  say "Creating venv"
+  python3 -m venv "$WORKDIR/.venv"
+fi
+# shellcheck disable=SC1091
+source "$WORKDIR/.venv/bin/activate"
+pip install --quiet --upgrade pip
+pip install --quiet -e "$REPO_ROOT/packages/fipsagents[server]" aiosqlite
+pip install --quiet -e "$ADAPTER_DIR"
+ok "fipsagents + llm-adapter installed"
+
+# ---- agent files -----------------------------------------------------------
+
+cat >"$WORKDIR/agent/prompts/system.md" <<'EOF'
+---
+name: system
+description: System prompt for the local Anthropic-backed smoke agent
+---
+
+You are a helpful assistant running locally for end-to-end testing of
+the user-feedback feature. Keep replies concise and friendly.
+EOF
+
+cat >"$WORKDIR/agent/agent.yaml" <<EOF
+agent:
+  name: anthropic-smoke
+  description: "Real Claude Haiku via the local adapter sidecar"
+  version: 0.0.0
+model:
+  # provider: anthropic tells the framework to route through the
+  # adapter sidecar. The endpoint here is informational — the
+  # framework rewrites it to http://localhost:\${ADAPTER_PORT}/v1.
+  provider: anthropic
+  endpoint: http://127.0.0.1:${ADAPTER_PORT}/v1
+  name: ${MODEL}
+  temperature: 0.7
+  max_tokens: 1024
+mcp_servers: []
+tools:
+  local_dir: ./tools
+  visibility_default: agent_only
+prompts:
+  dir: ./prompts
+  system: system
+loop:
+  max_iterations: 3
+logging:
+  level: INFO
+server:
+  host: 127.0.0.1
+  port: ${AGENT_PORT}
+  storage:
+    backend: sqlite
+    sqlite_path: ${WORKDIR}/agent/agent.db
+  sessions:
+    enabled: false
+  traces:
+    enabled: true
+    sampling_rate: 1.0
+  feedback:
+    enabled: true
+    max_age_hours: 720
+  metrics:
+    enabled: false
+EOF
+
+cat >"$WORKDIR/agent/run_agent.py" <<EOF
+"""Tiny BaseAgent subclass for the Anthropic-backed smoke stack.
+
+Monkey-patches the framework's hardcoded adapter port so the sidecar
+can run on a non-standard port without colliding with whatever else
+the developer has on :8081.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Override the hardcoded adapter port BEFORE BaseAgent imports it.
+import fipsagents.baseagent.config as _bcfg
+_bcfg._ADAPTER_PORT = ${ADAPTER_PORT}
+
+from fipsagents.baseagent import BaseAgent, StepResult
+from fipsagents.server import OpenAIChatServer
+
+
+class AnthropicSmokeAgent(BaseAgent):
+    async def step(self) -> StepResult:
+        response = await self.call_model()
+        return StepResult.done(response.content or "")
+
+
+if __name__ == "__main__":
+    cfg = Path(sys.argv[1])
+    server = OpenAIChatServer(
+        AnthropicSmokeAgent, config_path=cfg, base_dir=cfg.parent,
+    )
+    server.run(host="127.0.0.1", port=int(sys.argv[2]))
+EOF
+
+ok "agent files written to $WORKDIR/agent"
+
+# ---- start adapter ---------------------------------------------------------
+
+say "Starting llm-adapter on :$ADAPTER_PORT (provider=anthropic, model=$MODEL)"
+ADAPTER_LOG="$WORKDIR/logs/adapter.log"
+( exec env \
+    ADAPTER_PROVIDER=anthropic \
+    ADAPTER_PORT="$ADAPTER_PORT" \
+    ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+    LOG_LEVEL=INFO \
+    python -m llm_adapter.app \
+) >"$ADAPTER_LOG" 2>&1 &
+ADAPTER_PID=$!
+record_pid "$ADAPTER_PID" "adapter"
+
+for _ in $(seq 1 40); do
+  if curl -fs "http://127.0.0.1:$ADAPTER_PORT/healthz" >/dev/null 2>&1; then
+    ok "adapter ready (pid $ADAPTER_PID)"
+    break
+  fi
+  sleep 0.25
+done
+curl -fs "http://127.0.0.1:$ADAPTER_PORT/healthz" >/dev/null 2>&1 \
+  || die "adapter did not come up; tail of $ADAPTER_LOG"
+
+# ---- start agent -----------------------------------------------------------
+
+say "Starting agent on :$AGENT_PORT"
+AGENT_LOG="$WORKDIR/logs/agent.log"
+( cd "$WORKDIR/agent" \
+    && exec env OPENAI_API_KEY="not-required" \
+       python run_agent.py agent.yaml "$AGENT_PORT" \
+) >"$AGENT_LOG" 2>&1 &
+AGENT_PID=$!
+record_pid "$AGENT_PID" "agent"
+
+for _ in $(seq 1 60); do
+  if curl -fs "http://127.0.0.1:$AGENT_PORT/healthz" >/dev/null 2>&1; then
+    ok "agent ready (pid $AGENT_PID)"
+    break
+  fi
+  sleep 0.25
+done
+curl -fs "http://127.0.0.1:$AGENT_PORT/healthz" >/dev/null 2>&1 \
+  || die "agent did not come up; tail of $AGENT_LOG"
+
+# ---- start gateway ---------------------------------------------------------
+
+say "Building + starting gateway on :$GATEWAY_PORT"
+GATEWAY_BIN="$WORKDIR/gateway-server"
+( cd "$GATEWAY_REPO" && go build -o "$GATEWAY_BIN" ./cmd/server ) \
+  || die "gateway build failed"
+
+GATEWAY_LOG="$WORKDIR/logs/gateway.log"
+( exec env BACKEND_URL="http://127.0.0.1:$AGENT_PORT" PORT="$GATEWAY_PORT" \
+    "$GATEWAY_BIN" \
+) >"$GATEWAY_LOG" 2>&1 &
+GATEWAY_PID=$!
+record_pid "$GATEWAY_PID" "gateway"
+
+for _ in $(seq 1 40); do
+  if curl -fs "http://127.0.0.1:$GATEWAY_PORT/healthz" >/dev/null 2>&1; then
+    ok "gateway ready (pid $GATEWAY_PID)"
+    break
+  fi
+  sleep 0.25
+done
+curl -fs "http://127.0.0.1:$GATEWAY_PORT/healthz" >/dev/null 2>&1 \
+  || die "gateway did not come up; tail of $GATEWAY_LOG"
+
+# ---- start UI --------------------------------------------------------------
+
+say "Building + starting UI on :$UI_PORT"
+UI_BIN="$WORKDIR/ui-server"
+( cd "$UI_REPO" && go build -o "$UI_BIN" ./cmd/server ) \
+  || die "UI build failed"
+
+UI_LOG="$WORKDIR/logs/ui.log"
+( exec env API_URL="http://127.0.0.1:$GATEWAY_PORT" PORT="$UI_PORT" \
+    "$UI_BIN" \
+) >"$UI_LOG" 2>&1 &
+UI_PID=$!
+record_pid "$UI_PID" "ui"
+
+for _ in $(seq 1 40); do
+  if curl -fs "http://127.0.0.1:$UI_PORT/healthz" >/dev/null 2>&1; then
+    ok "UI ready (pid $UI_PID)"
+    break
+  fi
+  sleep 0.25
+done
+curl -fs "http://127.0.0.1:$UI_PORT/healthz" >/dev/null 2>&1 \
+  || die "UI did not come up; tail of $UI_LOG"
+
+# ---- one-shot sanity round-trip --------------------------------------------
+
+say "Sanity check: end-to-end chat through the whole stack"
+SANITY_HDR="$WORKDIR/logs/sanity.headers"
+SANITY_BODY="$WORKDIR/logs/sanity.body"
+if curl -sf -D "$SANITY_HDR" -o "$SANITY_BODY" \
+     -X POST "http://127.0.0.1:$UI_PORT/v1/chat/completions" \
+     -H 'Content-Type: application/json' \
+     -d '{"messages":[{"role":"user","content":"Reply with exactly: pong"}],"stream":false}' ; then
+  TRACE_ID=$(awk -F': ' 'tolower($1)=="x-trace-id"{gsub(/\r/,"");print $2}' "$SANITY_HDR" | tr -d ' ')
+  CONTENT=$(jq -r '.choices[0].message.content // empty' "$SANITY_BODY" 2>/dev/null)
+  if [ -n "$TRACE_ID" ] && [ -n "$CONTENT" ]; then
+    ok "real-API round trip succeeded"
+    echo "      trace_id : $TRACE_ID"
+    echo "      reply    : $(echo "$CONTENT" | head -c 80)"
+  else
+    echo "      $(c_red 'partial response — trace_id or content missing')"
+    echo "      headers: $(tr -d '\r' <"$SANITY_HDR" | head -5)"
+    echo "      body:    $(head -c 200 "$SANITY_BODY")"
+  fi
+else
+  echo "      $(c_red 'sanity request failed') — see $SANITY_BODY"
+fi
+
+# ---- summary ---------------------------------------------------------------
+
+cat <<EOF
+
+$(c_green '✓ Stack is up.')
+
+  UI       http://127.0.0.1:$UI_PORT     ← open this in a browser
+  Gateway  http://127.0.0.1:$GATEWAY_PORT
+  Agent    http://127.0.0.1:$AGENT_PORT
+  Adapter  http://127.0.0.1:$ADAPTER_PORT  (Anthropic, model=$MODEL)
+
+  PIDs     $(awk '{printf "%s=%s ", $2, $1}' "$PIDFILE")
+  Logs     $WORKDIR/logs/
+
+Chat from a terminal:
+  curl -s -X POST http://127.0.0.1:$UI_PORT/v1/chat/completions \\
+    -H 'Content-Type: application/json' \\
+    -d '{"messages":[{"role":"user","content":"hi"}],"stream":false}' | jq
+
+Inspect feedback after clicking thumbs in the browser:
+  curl -s http://127.0.0.1:$AGENT_PORT/v1/feedback | jq
+
+Stop everything:
+  $0 --stop
+EOF

--- a/scripts/smoke-feedback.sh
+++ b/scripts/smoke-feedback.sh
@@ -11,7 +11,8 @@
 #   5. POST /v1/feedback without trace_id (server synthesises one)
 #   6. GET /v1/feedback?trace_id=... returns the record we wrote
 #   7. GET /v1/feedback/stats?window=hour returns aggregated counts
-#   8. (gateway) auth headers (Authorization, X-User-ID) reach the backend
+#   8. (gateway) anonymous-mode auth: gateway strips spoofed X-Auth-* and
+#      projects X-Auth-Subject=anonymous (gateway-template#21 v1)
 #
 # No real LLM is required — the stub agent returns a fixed canned reply
 # so the script can run offline.
@@ -375,17 +376,27 @@ else
   fail "stats unexpected" "got total=$TOT up=$UP down=$DOWN" "raw: $STATS"
 fi
 
-section "Gateway pass-through with auth headers"
+section "Gateway anonymous-mode auth strips spoofed X-Auth-*"
+# Try to forge identity. Gateway in anonymous mode (default) must strip
+# inbound X-Auth-* and project X-Auth-Subject=anonymous.
 gw_fb_resp=$(curl -s -o "$WORKDIR/gw_fb.body" -w '%{http_code}' \
   -X POST "http://127.0.0.1:$GATEWAY_PORT/v1/feedback" \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer smoke-token' \
-  -H 'X-User-ID: smoke-tester' \
+  -H 'X-Auth-Subject: spoofed-admin' \
   -d "{\"trace_id\":\"$TRACE_FOR_FB\",\"rating\":1,\"comment\":\"via gateway\"}")
 if [ "$gw_fb_resp" = "201" ]; then
   pass "POST /v1/feedback via gateway returned 201"
 else
   fail "POST /v1/feedback via gateway returned $gw_fb_resp" "$(cat "$WORKDIR/gw_fb.body")"
+fi
+# Verify the spoofed subject was overwritten with "anonymous".
+GW_FB_ID=$(jq -r '.feedback_id' < "$WORKDIR/gw_fb.body")
+GW_FB_RECORD=$(curl -sf "http://127.0.0.1:$AGENT_PORT/v1/feedback?trace_id=$TRACE_FOR_FB" \
+  | jq -r --arg id "$GW_FB_ID" '.[] | select(.feedback_id == $id) | .user_id')
+if [ "$GW_FB_RECORD" = "anonymous" ]; then
+  pass "spoofed X-Auth-Subject stripped; recorded as anonymous"
+else
+  fail "X-Auth-Subject spoofing not stripped" "got user_id=$GW_FB_RECORD"
 fi
 
 section "GET /v1/feedback via gateway returns 3 records"
@@ -469,8 +480,6 @@ section "POST /v1/feedback through UI proxy → agent"
 ui_fb_resp=$(curl -s -o "$WORKDIR/ui_fb.body" -w '%{http_code}' \
   -X POST "http://127.0.0.1:$UI_PORT/v1/feedback" \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer ui-token' \
-  -H 'X-User-ID: ui-tester' \
   -d "{\"trace_id\":\"$TRACE_FOR_FB\",\"rating\":-1,\"comment\":\"[Inaccurate] from UI proxy\"}")
 if [ "$ui_fb_resp" = "201" ]; then
   pass "POST /v1/feedback via UI → 201"

--- a/scripts/smoke-feedback.sh
+++ b/scripts/smoke-feedback.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# Smoke test for the user-feedback feature track.
+#
+# Spins up a stub agent + the gateway against your local checkout and
+# exercises every interesting path:
+#
+#   1. X-Trace-Id header on sync chat completion
+#   2. trace_id field on the final SSE usage chunk (streaming)
+#   3. POST /v1/feedback round-trip via the agent (sqlite store)
+#   4. POST /v1/feedback via the gateway with auth headers forwarded
+#   5. POST /v1/feedback without trace_id (server synthesises one)
+#   6. GET /v1/feedback?trace_id=... returns the record we wrote
+#   7. GET /v1/feedback/stats?window=hour returns aggregated counts
+#   8. (gateway) auth headers (Authorization, X-User-ID) reach the backend
+#
+# No real LLM is required — the stub agent returns a fixed canned reply
+# so the script can run offline.
+#
+# Usage:
+#   scripts/smoke-feedback.sh                      # run all tests
+#   scripts/smoke-feedback.sh --keep-running       # leave services up at end
+#   AGENT_PORT=18080 GATEWAY_PORT=18090 scripts/smoke-feedback.sh
+#
+# Exit code is the number of failures (0 = all passed).
+
+set -uo pipefail
+
+# ---- config ----------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATEWAY_REPO="${GATEWAY_REPO:-$HOME/Developer/AGENTS/gateway-template}"
+AGENT_PORT="${AGENT_PORT:-18080}"
+GATEWAY_PORT="${GATEWAY_PORT:-18090}"
+WORKDIR="$(mktemp -d -t fipsagents-smoke-XXXXXX)"
+KEEP_RUNNING=0
+[ "${1:-}" = "--keep-running" ] && KEEP_RUNNING=1
+
+AGENT_LOG="$WORKDIR/agent.log"
+GATEWAY_LOG="$WORKDIR/gateway.log"
+AGENT_PID=""
+GATEWAY_PID=""
+PASS=0
+FAIL=0
+
+# ---- output helpers --------------------------------------------------------
+
+c_red()   { printf '\033[31m%s\033[0m' "$1"; }
+c_green() { printf '\033[32m%s\033[0m' "$1"; }
+c_dim()   { printf '\033[2m%s\033[0m' "$1"; }
+
+pass() { PASS=$((PASS+1)); echo "  $(c_green PASS) $1"; }
+fail() {
+  FAIL=$((FAIL+1))
+  echo "  $(c_red FAIL) $1"
+  shift
+  for line in "$@"; do
+    echo "       $(c_dim "$line")"
+  done
+}
+section() { echo; echo "== $1 =="; }
+
+cleanup() {
+  if [ "$KEEP_RUNNING" = "1" ]; then
+    echo
+    echo "Services left running:"
+    [ -n "$AGENT_PID" ]   && echo "  agent   pid=$AGENT_PID  port=$AGENT_PORT  log=$AGENT_LOG"
+    [ -n "$GATEWAY_PID" ] && echo "  gateway pid=$GATEWAY_PID port=$GATEWAY_PORT log=$GATEWAY_LOG"
+    echo "  workdir=$WORKDIR"
+    echo "Stop with: kill $AGENT_PID $GATEWAY_PID"
+    return
+  fi
+  [ -n "$AGENT_PID" ]   && kill "$AGENT_PID"   2>/dev/null || true
+  [ -n "$GATEWAY_PID" ] && kill "$GATEWAY_PID" 2>/dev/null || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# ---- prereq checks ---------------------------------------------------------
+
+section "Prerequisites"
+need() {
+  if command -v "$1" >/dev/null 2>&1; then
+    pass "$1 available"
+  else
+    fail "$1 not found in PATH"
+  fi
+}
+need python3
+need go
+need curl
+need jq
+
+if [ ! -d "$GATEWAY_REPO" ]; then
+  fail "gateway-template not found at $GATEWAY_REPO" \
+       "set GATEWAY_REPO=/path/to/gateway-template if it lives elsewhere"
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Prerequisite checks failed; aborting."
+  exit "$FAIL"
+fi
+
+# ---- venv + install --------------------------------------------------------
+
+section "Setting up venv"
+python3 -m venv "$WORKDIR/.venv"
+# shellcheck disable=SC1091
+source "$WORKDIR/.venv/bin/activate"
+pip install --quiet --upgrade pip
+pip install --quiet -e "${REPO_ROOT}/packages/fipsagents[server]" aiosqlite
+pass "fipsagents installed in editable mode (server + aiosqlite)"
+
+# ---- write stub agent ------------------------------------------------------
+
+section "Building stub agent"
+
+mkdir -p "$WORKDIR/agent/prompts" "$WORKDIR/agent/tools"
+
+cat >"$WORKDIR/agent/prompts/system.md" <<'EOF'
+---
+name: system
+description: Stub system prompt for smoke testing
+---
+
+You are a stub assistant for the fipsagents feedback smoke test.
+EOF
+
+cat >"$WORKDIR/agent/agent.yaml" <<EOF
+agent:
+  name: smoke-stub
+  description: "Stub agent for the feedback smoke test"
+  version: 0.0.0
+model:
+  provider: openai
+  endpoint: http://127.0.0.1:1/v1
+  name: stub-model
+  temperature: 0.0
+  max_tokens: 16
+mcp_servers: []
+tools:
+  local_dir: ./tools
+  visibility_default: agent_only
+prompts:
+  dir: ./prompts
+  system: system
+loop:
+  max_iterations: 1
+logging:
+  level: WARNING
+server:
+  host: 127.0.0.1
+  port: ${AGENT_PORT}
+  storage:
+    backend: sqlite
+    sqlite_path: ${WORKDIR}/agent/agent.db
+  sessions:
+    enabled: false
+  traces:
+    enabled: true
+    sampling_rate: 1.0
+  feedback:
+    enabled: true
+    max_age_hours: 720
+  metrics:
+    enabled: false
+EOF
+
+# Stub agent + launcher.  Bypasses the real LLM by overriding astep_stream
+# to yield a deterministic content delta + StreamComplete.
+cat >"$WORKDIR/agent/run_stub.py" <<'EOF'
+"""Run a stub OpenAIChatServer for smoke testing.  No LLM traffic."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from fipsagents.baseagent import BaseAgent, StepResult
+from fipsagents.baseagent.config import load_config
+from fipsagents.baseagent.events import ContentDelta, StreamComplete, StreamMetrics
+from fipsagents.server import OpenAIChatServer
+
+
+class StubAgent(BaseAgent):
+    async def setup(self) -> None:
+        # Load the config but skip LLM/MCP wiring so the smoke test can
+        # run with no real model behind it.
+        if self._provided_config is not None:
+            self.config = self._provided_config
+        else:
+            self.config = load_config(self._config_path)
+        self._setup_done = True
+
+    async def shutdown(self) -> None:
+        pass
+
+    async def step(self) -> StepResult:  # type: ignore[override]
+        return StepResult.done("stub response")
+
+    async def astep_stream(self, *, max_iterations: int = 1, **_kw):
+        yield ContentDelta(content="stub ")
+        yield ContentDelta(content="response")
+        yield StreamComplete(
+            finish_reason="stop",
+            metrics=StreamMetrics(
+                prompt_tokens=4,
+                completion_tokens=2,
+                total_tokens=6,
+                time_to_first_content=0.01,
+                total_time=0.02,
+            ),
+        )
+
+
+if __name__ == "__main__":
+    cfg = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("agent.yaml")
+    server = OpenAIChatServer(StubAgent, config_path=cfg, base_dir=cfg.parent)
+    server.run(host="127.0.0.1", port=int(sys.argv[2]))
+EOF
+
+pass "stub agent and config written to $WORKDIR/agent"
+
+# ---- start agent -----------------------------------------------------------
+
+section "Starting agent on :$AGENT_PORT"
+( cd "$WORKDIR/agent" && python run_stub.py agent.yaml "$AGENT_PORT" >"$AGENT_LOG" 2>&1 ) &
+AGENT_PID=$!
+
+# Wait for /healthz.
+for _ in $(seq 1 40); do
+  if curl -fs "http://127.0.0.1:$AGENT_PORT/healthz" >/dev/null 2>&1; then
+    pass "agent ready (pid $AGENT_PID)"
+    break
+  fi
+  sleep 0.25
+done
+if ! curl -fs "http://127.0.0.1:$AGENT_PORT/healthz" >/dev/null 2>&1; then
+  fail "agent did not come up; tail of $AGENT_LOG:" \
+       "$(tail -n 20 "$AGENT_LOG" 2>/dev/null | sed 's/^/        /')"
+  exit "$FAIL"
+fi
+
+# ---- build + start gateway -------------------------------------------------
+
+section "Starting gateway on :$GATEWAY_PORT"
+GATEWAY_BIN="$WORKDIR/gateway-server"
+( cd "$GATEWAY_REPO" && go build -o "$GATEWAY_BIN" ./cmd/server ) \
+  && pass "gateway binary built" \
+  || { fail "gateway build failed"; exit "$FAIL"; }
+
+BACKEND_URL="http://127.0.0.1:$AGENT_PORT" PORT="$GATEWAY_PORT" \
+  "$GATEWAY_BIN" >"$GATEWAY_LOG" 2>&1 &
+GATEWAY_PID=$!
+
+for _ in $(seq 1 40); do
+  if curl -fs "http://127.0.0.1:$GATEWAY_PORT/healthz" >/dev/null 2>&1; then
+    pass "gateway ready (pid $GATEWAY_PID)"
+    break
+  fi
+  sleep 0.25
+done
+if ! curl -fs "http://127.0.0.1:$GATEWAY_PORT/healthz" >/dev/null 2>&1; then
+  fail "gateway did not come up; tail of $GATEWAY_LOG:" \
+       "$(tail -n 20 "$GATEWAY_LOG" 2>/dev/null | sed 's/^/        /')"
+  exit "$FAIL"
+fi
+
+# ---- helpers used by the assertions ----------------------------------------
+
+# trace_id syntax we generate: trace_<16 hex>.  Also accept W3C 32-hex
+# trace IDs in case a propagated traceparent is in play.
+TRACE_RE='^(trace_[0-9a-f]{16}|[0-9a-f]{32})$'
+
+# ---- smoke tests -----------------------------------------------------------
+
+section "Sync chat completion → X-Trace-Id header"
+sync_resp_hdr="$WORKDIR/sync.headers"
+sync_resp_body="$WORKDIR/sync.body"
+curl -sf -D "$sync_resp_hdr" -o "$sync_resp_body" \
+  -X POST "http://127.0.0.1:$AGENT_PORT/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"hi"}],"stream":false}'
+SYNC_TRACE=$(awk -F': ' 'tolower($1)=="x-trace-id"{gsub(/\r/,"");print $2}' "$sync_resp_hdr" | tr -d ' ')
+if [[ "$SYNC_TRACE" =~ $TRACE_RE ]]; then
+  pass "X-Trace-Id present and well-formed: $SYNC_TRACE"
+else
+  fail "X-Trace-Id missing or malformed" "got: '$SYNC_TRACE'" "headers: $(tr -d '\r' <"$sync_resp_hdr" | head -10)"
+fi
+
+section "Streaming chat completion → trace_id on usage chunk"
+stream_body="$WORKDIR/stream.sse"
+stream_hdr="$WORKDIR/stream.headers"
+curl -sN -D "$stream_hdr" -o "$stream_body" \
+  -X POST "http://127.0.0.1:$AGENT_PORT/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"hi"}],"stream":true}'
+STREAM_HDR_TRACE=$(awk -F': ' 'tolower($1)=="x-trace-id"{gsub(/\r/,"");print $2}' "$stream_hdr" | tr -d ' ')
+if [[ "$STREAM_HDR_TRACE" =~ $TRACE_RE ]]; then
+  pass "X-Trace-Id present on streaming response: $STREAM_HDR_TRACE"
+else
+  fail "X-Trace-Id missing on streaming response" "got: '$STREAM_HDR_TRACE'"
+fi
+
+# Pull trace_id out of the usage chunk (the empty-choices frame).
+USAGE_TRACE=$(grep '^data: {' "$stream_body" \
+  | sed 's/^data: //' \
+  | jq -r 'select(.choices==[]) | .trace_id // empty' \
+  | head -1)
+if [[ "$USAGE_TRACE" =~ $TRACE_RE ]]; then
+  pass "usage chunk carries trace_id: $USAGE_TRACE"
+else
+  fail "trace_id missing from usage chunk" "got: '$USAGE_TRACE'"
+fi
+if [ "$STREAM_HDR_TRACE" = "$USAGE_TRACE" ]; then
+  pass "header and usage-chunk trace_id agree"
+else
+  fail "header and usage-chunk trace_id disagree" \
+       "header=$STREAM_HDR_TRACE" "chunk=$USAGE_TRACE"
+fi
+
+section "POST /v1/feedback (with trace_id) → 201 + record retrievable"
+TRACE_FOR_FB="$STREAM_HDR_TRACE"
+fb_resp=$(curl -s -o "$WORKDIR/fb1.body" -w '%{http_code}' \
+  -X POST "http://127.0.0.1:$AGENT_PORT/v1/feedback" \
+  -H 'Content-Type: application/json' \
+  -d "{\"trace_id\":\"$TRACE_FOR_FB\",\"rating\":1,\"comment\":\"smoke 👍\"}")
+if [ "$fb_resp" = "201" ]; then
+  FB1_ID=$(jq -r .feedback_id <"$WORKDIR/fb1.body")
+  pass "POST /v1/feedback returned 201 (id=$FB1_ID)"
+else
+  fail "POST /v1/feedback returned $fb_resp" "$(cat "$WORKDIR/fb1.body")"
+fi
+
+LIST_RESP=$(curl -sf "http://127.0.0.1:$AGENT_PORT/v1/feedback?trace_id=$TRACE_FOR_FB")
+if [ "$(echo "$LIST_RESP" | jq 'length')" = "1" ] \
+   && [ "$(echo "$LIST_RESP" | jq -r '.[0].rating')" = "1" ] \
+   && [ "$(echo "$LIST_RESP" | jq -r '.[0].trace_id')" = "$TRACE_FOR_FB" ]; then
+  pass "GET /v1/feedback?trace_id=… returns the record"
+else
+  fail "GET /v1/feedback?trace_id=… returned unexpected payload" "$LIST_RESP"
+fi
+
+section "POST /v1/feedback without trace_id → server synthesises one"
+fb2_resp=$(curl -s -o "$WORKDIR/fb2.body" -w '%{http_code}' \
+  -X POST "http://127.0.0.1:$AGENT_PORT/v1/feedback" \
+  -H 'Content-Type: application/json' \
+  -d '{"rating":-1,"comment":"orphan"}')
+if [ "$fb2_resp" = "201" ]; then
+  pass "POST /v1/feedback (no trace_id) returned 201"
+else
+  fail "POST /v1/feedback (no trace_id) returned $fb2_resp" "$(cat "$WORKDIR/fb2.body")"
+fi
+
+section "GET /v1/feedback/stats?window=hour"
+STATS=$(curl -sf "http://127.0.0.1:$AGENT_PORT/v1/feedback/stats?window=hour")
+TOT=$(echo "$STATS" | jq '[.[].total]|add // 0')
+UP=$(echo "$STATS"  | jq '[.[].thumbs_up]|add // 0')
+DOWN=$(echo "$STATS"| jq '[.[].thumbs_down]|add // 0')
+if [ "$TOT" = "2" ] && [ "$UP" = "1" ] && [ "$DOWN" = "1" ]; then
+  pass "stats: total=$TOT up=$UP down=$DOWN"
+else
+  fail "stats unexpected" "got total=$TOT up=$UP down=$DOWN" "raw: $STATS"
+fi
+
+section "Gateway pass-through with auth headers"
+gw_fb_resp=$(curl -s -o "$WORKDIR/gw_fb.body" -w '%{http_code}' \
+  -X POST "http://127.0.0.1:$GATEWAY_PORT/v1/feedback" \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer smoke-token' \
+  -H 'X-User-ID: smoke-tester' \
+  -d "{\"trace_id\":\"$TRACE_FOR_FB\",\"rating\":1,\"comment\":\"via gateway\"}")
+if [ "$gw_fb_resp" = "201" ]; then
+  pass "POST /v1/feedback via gateway returned 201"
+else
+  fail "POST /v1/feedback via gateway returned $gw_fb_resp" "$(cat "$WORKDIR/gw_fb.body")"
+fi
+
+section "GET /v1/feedback via gateway returns 3 records"
+GW_LIST=$(curl -sf "http://127.0.0.1:$GATEWAY_PORT/v1/feedback?limit=10")
+GW_CT=$(echo "$GW_LIST" | jq 'length')
+if [ "$GW_CT" = "3" ]; then
+  pass "gateway list returned 3 records"
+else
+  fail "gateway list returned $GW_CT records (expected 3)" "$GW_LIST"
+fi
+
+section "GET /v1/feedback/stats via gateway"
+GW_STATS=$(curl -sf "http://127.0.0.1:$GATEWAY_PORT/v1/feedback/stats?window=hour")
+GW_TOT=$(echo "$GW_STATS" | jq '[.[].total]|add // 0')
+if [ "$GW_TOT" = "3" ]; then
+  pass "gateway stats: total=$GW_TOT"
+else
+  fail "gateway stats unexpected" "got total=$GW_TOT" "raw: $GW_STATS"
+fi
+
+section "Gateway rejects unsupported method"
+M_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+  -X DELETE "http://127.0.0.1:$GATEWAY_PORT/v1/feedback")
+if [ "$M_CODE" = "405" ]; then
+  pass "DELETE /v1/feedback → 405 (method not allowed)"
+else
+  fail "DELETE /v1/feedback returned $M_CODE (expected 405)"
+fi
+
+# ---- summary ---------------------------------------------------------------
+
+echo
+TOTAL=$((PASS+FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  echo "$(c_green "All $TOTAL checks passed.")"
+else
+  echo "$(c_red "$FAIL of $TOTAL checks failed.")"
+  echo
+  echo "Logs:"
+  echo "  agent:   $AGENT_LOG"
+  echo "  gateway: $GATEWAY_LOG"
+fi
+
+exit "$FAIL"

--- a/scripts/smoke-feedback.sh
+++ b/scripts/smoke-feedback.sh
@@ -29,16 +29,20 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATEWAY_REPO="${GATEWAY_REPO:-$HOME/Developer/AGENTS/gateway-template}"
+UI_REPO="${UI_REPO:-$HOME/Developer/AGENTS/ui-template}"
 AGENT_PORT="${AGENT_PORT:-18080}"
 GATEWAY_PORT="${GATEWAY_PORT:-18090}"
+UI_PORT="${UI_PORT:-13000}"
 WORKDIR="$(mktemp -d -t fipsagents-smoke-XXXXXX)"
 KEEP_RUNNING=0
 [ "${1:-}" = "--keep-running" ] && KEEP_RUNNING=1
 
 AGENT_LOG="$WORKDIR/agent.log"
 GATEWAY_LOG="$WORKDIR/gateway.log"
+UI_LOG="$WORKDIR/ui.log"
 AGENT_PID=""
 GATEWAY_PID=""
+UI_PID=""
 PASS=0
 FAIL=0
 
@@ -65,12 +69,15 @@ cleanup() {
     echo "Services left running:"
     [ -n "$AGENT_PID" ]   && echo "  agent   pid=$AGENT_PID  port=$AGENT_PORT  log=$AGENT_LOG"
     [ -n "$GATEWAY_PID" ] && echo "  gateway pid=$GATEWAY_PID port=$GATEWAY_PORT log=$GATEWAY_LOG"
+    [ -n "$UI_PID" ]      && echo "  ui      pid=$UI_PID      port=$UI_PORT      log=$UI_LOG"
     echo "  workdir=$WORKDIR"
-    echo "Stop with: kill $AGENT_PID $GATEWAY_PID"
+    [ -n "$UI_PID" ] && echo "  open in browser: http://127.0.0.1:$UI_PORT"
+    echo "Stop with: kill $AGENT_PID $GATEWAY_PID $UI_PID"
     return
   fi
   [ -n "$AGENT_PID" ]   && kill "$AGENT_PID"   2>/dev/null || true
   [ -n "$GATEWAY_PID" ] && kill "$GATEWAY_PID" 2>/dev/null || true
+  [ -n "$UI_PID" ]      && kill "$UI_PID"      2>/dev/null || true
   rm -rf "$WORKDIR"
 }
 trap cleanup EXIT
@@ -93,6 +100,10 @@ need jq
 if [ ! -d "$GATEWAY_REPO" ]; then
   fail "gateway-template not found at $GATEWAY_REPO" \
        "set GATEWAY_REPO=/path/to/gateway-template if it lives elsewhere"
+fi
+if [ ! -d "$UI_REPO" ]; then
+  fail "ui-template not found at $UI_REPO" \
+       "set UI_REPO=/path/to/ui-template if it lives elsewhere"
 fi
 
 if [ "$FAIL" -gt 0 ]; then
@@ -223,7 +234,9 @@ pass "stub agent and config written to $WORKDIR/agent"
 # ---- start agent -----------------------------------------------------------
 
 section "Starting agent on :$AGENT_PORT"
-( cd "$WORKDIR/agent" && python run_stub.py agent.yaml "$AGENT_PORT" >"$AGENT_LOG" 2>&1 ) &
+# `exec` inside the subshell so $! is python's PID, not the subshell's.
+# Without exec, killing $! kills the wrapper bash and orphans python.
+( cd "$WORKDIR/agent" && exec python run_stub.py agent.yaml "$AGENT_PORT" ) >"$AGENT_LOG" 2>&1 &
 AGENT_PID=$!
 
 # Wait for /healthz.
@@ -248,8 +261,8 @@ GATEWAY_BIN="$WORKDIR/gateway-server"
   && pass "gateway binary built" \
   || { fail "gateway build failed"; exit "$FAIL"; }
 
-BACKEND_URL="http://127.0.0.1:$AGENT_PORT" PORT="$GATEWAY_PORT" \
-  "$GATEWAY_BIN" >"$GATEWAY_LOG" 2>&1 &
+( exec env BACKEND_URL="http://127.0.0.1:$AGENT_PORT" PORT="$GATEWAY_PORT" \
+    "$GATEWAY_BIN" ) >"$GATEWAY_LOG" 2>&1 &
 GATEWAY_PID=$!
 
 for _ in $(seq 1 40); do
@@ -402,6 +415,91 @@ else
   fail "DELETE /v1/feedback returned $M_CODE (expected 405)"
 fi
 
+# ---- UI tier ---------------------------------------------------------------
+
+section "Starting UI on :$UI_PORT"
+UI_BIN="$WORKDIR/ui-server"
+( cd "$UI_REPO" && go build -o "$UI_BIN" ./cmd/server ) \
+  && pass "UI binary built" \
+  || { fail "UI build failed"; exit "$FAIL"; }
+
+( exec env API_URL="http://127.0.0.1:$GATEWAY_PORT" PORT="$UI_PORT" \
+    "$UI_BIN" ) >"$UI_LOG" 2>&1 &
+UI_PID=$!
+
+for _ in $(seq 1 40); do
+  if curl -fs "http://127.0.0.1:$UI_PORT/healthz" >/dev/null 2>&1; then
+    pass "UI ready (pid $UI_PID)"
+    break
+  fi
+  sleep 0.25
+done
+if ! curl -fs "http://127.0.0.1:$UI_PORT/healthz" >/dev/null 2>&1; then
+  fail "UI did not come up; tail of $UI_LOG:" \
+       "$(tail -n 20 "$UI_LOG" 2>/dev/null | sed 's/^/        /')"
+  exit "$FAIL"
+fi
+
+section "UI serves the chat HTML"
+HTML=$(curl -sf "http://127.0.0.1:$UI_PORT/")
+if echo "$HTML" | grep -q '<script src="app.js">'; then
+  pass "GET / returns the chat HTML (app.js linked)"
+else
+  fail "GET / did not return expected HTML" "$(echo "$HTML" | head -5)"
+fi
+
+section "UI ships the new feedback JS + CSS"
+APPJS=$(curl -sf "http://127.0.0.1:$UI_PORT/app.js")
+if echo "$APPJS" | grep -q "createFeedbackControls" \
+   && echo "$APPJS" | grep -q "/v1/feedback" \
+   && echo "$APPJS" | grep -q "X-Trace-Id"; then
+  pass "app.js exposes feedback hooks (createFeedbackControls, /v1/feedback, X-Trace-Id)"
+else
+  fail "app.js missing expected feedback symbols"
+fi
+CSS=$(curl -sf "http://127.0.0.1:$UI_PORT/style.css")
+if echo "$CSS" | grep -q "feedback-controls" \
+   && echo "$CSS" | grep -q "feedback-modal"; then
+  pass "style.css ships the feedback selectors"
+else
+  fail "style.css missing .feedback-controls / .feedback-modal"
+fi
+
+section "POST /v1/feedback through UI proxy → agent"
+ui_fb_resp=$(curl -s -o "$WORKDIR/ui_fb.body" -w '%{http_code}' \
+  -X POST "http://127.0.0.1:$UI_PORT/v1/feedback" \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer ui-token' \
+  -H 'X-User-ID: ui-tester' \
+  -d "{\"trace_id\":\"$TRACE_FOR_FB\",\"rating\":-1,\"comment\":\"[Inaccurate] from UI proxy\"}")
+if [ "$ui_fb_resp" = "201" ]; then
+  pass "POST /v1/feedback via UI → 201"
+else
+  fail "POST /v1/feedback via UI returned $ui_fb_resp" "$(cat "$WORKDIR/ui_fb.body")"
+fi
+
+section "GET /v1/feedback through UI proxy returns 4 records"
+UI_LIST=$(curl -sf "http://127.0.0.1:$UI_PORT/v1/feedback?limit=10")
+UI_CT=$(echo "$UI_LIST" | jq 'length')
+if [ "$UI_CT" = "4" ]; then
+  pass "UI list returned 4 records"
+else
+  fail "UI list returned $UI_CT records (expected 4)" "$UI_LIST"
+fi
+
+section "Sync chat completion through full UI → agent path"
+ui_sync_hdr="$WORKDIR/ui_sync.headers"
+curl -sf -D "$ui_sync_hdr" -o /dev/null \
+  -X POST "http://127.0.0.1:$UI_PORT/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"hi"}],"stream":false}'
+UI_SYNC_TRACE=$(awk -F': ' 'tolower($1)=="x-trace-id"{gsub(/\r/,"");print $2}' "$ui_sync_hdr" | tr -d ' ')
+if [[ "$UI_SYNC_TRACE" =~ $TRACE_RE ]]; then
+  pass "UI propagates X-Trace-Id end-to-end: $UI_SYNC_TRACE"
+else
+  fail "X-Trace-Id missing from UI sync response" "got: '$UI_SYNC_TRACE'"
+fi
+
 # ---- summary ---------------------------------------------------------------
 
 echo
@@ -414,6 +512,7 @@ else
   echo "Logs:"
   echo "  agent:   $AGENT_LOG"
   echo "  gateway: $GATEWAY_LOG"
+  [ -n "$UI_PID" ] && echo "  ui:      $UI_LOG"
 fi
 
 exit "$FAIL"


### PR DESCRIPTION
## Summary

Replaces #110 (auto-closed when its base branch was deleted on merge of #109). Rebased onto `main`; only the trace_id commits remain.

The feedback API takes a `trace_id` so ratings can be joined to the trace they refer to, but the trace_id was previously locked inside `TraceCollector` and never made it past the server. UI clients had no way to obtain a valid value.

This PR:

- **Always generates** a `trace_id` for every chat request (independent of sampling/persistence) and passes it through to the collector if one is built.
- **Surfaces it** two ways: `X-Trace-Id` response header on sync and streaming, and a top-level `trace_id` field on the final SSE usage chunk.
- **Honours W3C `traceparent`** propagation: when present, the parent's trace_id wins so distributed traces stay linked.
- Makes `CreateFeedbackRequest.trace_id` **optional** with server-side synthesis so clients without a trace_id can still record raw ratings (orphan records).

Unblocks the UI thumbs-up/-down feature in fips-agents/ui-template#15.

## Test plan

- [x] `pytest packages/fipsagents/tests/` — 645 passed, 20 skipped
- [x] Tests cover: X-Trace-Id header on sync, X-Trace-Id header + chunk field on streaming, traceparent override, optional trace_id in CreateFeedbackRequest, rating validation
- [x] Local smoke (`scripts/smoke-feedback.sh`) — 30/30 checks
- [x] Cluster proxy-mode validation in `auth-proxy-test` namespace