### PR TITLE
feat(server): HTTP-backed FeedbackStore/SessionStore/TraceStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the `fipsagents` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.13.0] - 2026-04-27
+
+### Added
+
+- **HTTP-backed store implementations** — `HttpSessionStore`, `HttpTraceStore`, `HttpFeedbackStore` in `fipsagents.server.http`. Drop-in replacements for the existing SQLite/Postgres backends that delegate persistence to a sibling [`fipsagents-platform`](https://github.com/fips-agents/fipsagents-platform) service over its REST surface. Closes the agent-side half of the Cross-Agent Platform Service work tracked in [#114](https://github.com/fips-agents/agent-template/issues/114) (architecture decision in [#112](https://github.com/fips-agents/agent-template/issues/112)).
+- **Per-store backend override** — `SessionsConfig`, `TracesConfig` and `FeedbackConfig` each gain an optional `backend: sqlite | postgres | http` field. When unset, the store inherits `storage.backend`. Lets an operator route, eg, `feedback.backend: http` while keeping sessions/traces on local SQLite.
+- **Platform routing config** — `StorageConfig` gains `platform_url` and `platform_token`. The static token is used for service-to-service flows; per-request `Authorization` headers from inbound chat requests take precedence and are forwarded to the platform via a contextvar populated by a new `_HttpStoreContextMiddleware`. W3C `traceparent` is forwarded the same way so platform writes participate in the same distributed trace as the chat completion that generated them.
+- **`platform-client` extra** — explicit opt-in marker for HTTP-backed deployments (httpx itself is already a core dependency).
+
+### Changed
+
+- `OpenAIChatServer._lifespan` now resolves each store's backend independently and only acquires a SQLite connection when at least one enabled store needs it. The housekeeping task is skipped entirely when every active store is HTTP-backed (the platform owns its own housekeeping cycle).
+
+### Notes
+
+- `delete_before()` on every `Http*Store` is a logged no-op — the platform service is responsible for housekeeping cross-tenant data.
+- `HttpFeedbackStore.add()` returns the platform-generated `feedback_id`; the agent's pre-generated id and `created_at` on the inbound `FeedbackRecord` are intentionally discarded (matches the platform's `POST /v1/feedback` contract).
+
 ## [0.12.0] - 2026-04-27
 
 ### Added

--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fipsagents"
-version = "0.12.0"
+version = "0.13.0"
 description = "Production-ready AI agent framework for FIPS/OpenShift environments"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -58,6 +58,12 @@ otel = [
 feedback = [
     "aiosqlite>=0.20.0",
     "asyncpg>=0.29.0",
+]
+platform-client = [
+    # httpx is already a core dependency; this extra is a documentation
+    # marker for ``backend: http`` deployments routing persistence to a
+    # sibling fipsagents-platform service.
+    "httpx",
 ]
 dev = [
     "pytest>=7.0",

--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -372,11 +372,18 @@ class StorageConfig(BaseModel):
     When ``backend`` is ``null`` (default), no persistence — features
     degrade gracefully to no-ops. ``sqlite`` uses a single file for
     both sessions and traces. ``postgres`` uses a shared connection pool.
+    ``http`` delegates to a sibling ``fipsagents-platform`` service over
+    REST; ``platform_url`` is required and ``platform_token`` is an
+    optional static bearer token for service-to-service flows
+    (per-request tokens forwarded from the inbound ``Authorization``
+    header take precedence when present).
     """
 
-    backend: Literal["sqlite", "postgres"] | None = None
+    backend: Literal["sqlite", "postgres", "http"] | None = None
     sqlite_path: str = "./agent.db"
     database_url: str = ""
+    platform_url: str = ""
+    platform_token: str = ""
 
     @field_validator("backend", mode="before")
     @classmethod
@@ -394,14 +401,32 @@ class StorageConfig(BaseModel):
         return v
 
 
-class SessionsConfig(BaseModel):
+class _PerStoreBackendMixin(BaseModel):
+    """Per-store override for ``StorageConfig.backend``.
+
+    When ``None`` the store inherits ``storage.backend``.  Allows mixing
+    backends — eg ``feedback.backend: http`` while sessions/traces stay
+    on local SQLite.
+    """
+
+    backend: Literal["sqlite", "postgres", "http"] | None = None
+
+    @field_validator("backend", mode="before")
+    @classmethod
+    def _coerce_empty_backend(cls, v: Any) -> Any:
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
+
+class SessionsConfig(_PerStoreBackendMixin):
     """Session persistence settings."""
 
     enabled: bool = False
     max_age_hours: int = Field(default=168, ge=0)
 
 
-class TracesConfig(BaseModel):
+class TracesConfig(_PerStoreBackendMixin):
     """Trace collection settings."""
 
     enabled: bool = False
@@ -418,7 +443,7 @@ class MetricsConfig(BaseModel):
     enabled: bool = False
 
 
-class FeedbackConfig(BaseModel):
+class FeedbackConfig(_PerStoreBackendMixin):
     """Feedback collection settings."""
 
     enabled: bool = False

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -14,6 +14,7 @@ from typing import Any, AsyncIterator
 try:
     from fastapi import Body, FastAPI, HTTPException, Request
     from fastapi.responses import JSONResponse, StreamingResponse
+    from starlette.middleware.base import BaseHTTPMiddleware
 except ImportError as exc:  # pragma: no cover — helpful error path
     raise ImportError(
         "fipsagents.server requires the [server] extra. "
@@ -51,6 +52,32 @@ logger = logging.getLogger(__name__)
 def _new_trace_id() -> str:
     """Generate a trace identifier matching ``TraceCollector``'s format."""
     return f"trace_{uuid.uuid4().hex[:16]}"
+
+
+class _HttpStoreContextMiddleware(BaseHTTPMiddleware):
+    """Forward inbound Authorization + traceparent to outgoing Http*Store calls.
+
+    Stores are stateless objects that don't see request scope.  This
+    middleware captures the headers into contextvars consumed by
+    :class:`fipsagents.server.http.\\_PlatformClient` so per-request
+    JWTs and distributed-trace context flow through to the platform
+    service without changing the SessionStore/TraceStore/FeedbackStore
+    ABCs.
+    """
+
+    async def dispatch(self, request, call_next):
+        # Lazy import: only matters when the http backend is configured.
+        from .http import set_request_context, reset_request_context
+
+        tokens = set_request_context(
+            authorization=request.headers.get("authorization")
+            or request.headers.get("Authorization"),
+            traceparent=request.headers.get("traceparent"),
+        )
+        try:
+            return await call_next(request)
+        finally:
+            reset_request_context(tokens)
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +132,7 @@ class OpenAIChatServer:
             version=version,
             lifespan=self._lifespan,
         )
+        self.app.add_middleware(_HttpStoreContextMiddleware)
         self._register_routes()
 
     # -- Lifespan ------------------------------------------------------------
@@ -121,10 +149,27 @@ class OpenAIChatServer:
         server_cfg = self._agent.config.server
         sqlite_conn = None
 
-        has_sqlite_feature = (
-            server_cfg.storage.backend == "sqlite"
-            and (server_cfg.sessions.enabled or server_cfg.traces.enabled or server_cfg.feedback.enabled)
+        # Per-store backend = explicit override or fall through to
+        # storage.backend.  An ``http`` backend is allowed at the per-store
+        # level even when storage.backend is None or ``sqlite`` — that's
+        # the whole point of the per-store override (eg feedback->http,
+        # sessions->sqlite).
+        sessions_backend = (
+            server_cfg.sessions.backend or server_cfg.storage.backend
+            if server_cfg.sessions.enabled else None
         )
+        traces_backend = (
+            server_cfg.traces.backend or server_cfg.storage.backend
+            if server_cfg.traces.enabled else None
+        )
+        feedback_backend = (
+            server_cfg.feedback.backend or server_cfg.storage.backend
+            if server_cfg.feedback.enabled else None
+        )
+
+        has_sqlite_feature = "sqlite" in {
+            sessions_backend, traces_backend, feedback_backend,
+        }
         if has_sqlite_feature:
             from .sqlite import SqliteConnectionManager
 
@@ -134,25 +179,31 @@ class OpenAIChatServer:
             )
 
         self._session_store = create_session_store(
-            server_cfg.storage.backend if server_cfg.sessions.enabled else None,
+            sessions_backend,
             sqlite_path=server_cfg.storage.sqlite_path,
             database_url=server_cfg.storage.database_url,
             sqlite_connection=sqlite_conn,
+            platform_url=server_cfg.storage.platform_url,
+            platform_token=server_cfg.storage.platform_token,
         )
         self._trace_store = create_trace_store(
-            server_cfg.storage.backend if server_cfg.traces.enabled else None,
+            traces_backend,
             sqlite_path=server_cfg.storage.sqlite_path,
             database_url=server_cfg.storage.database_url,
             sqlite_connection=sqlite_conn,
             exporter=server_cfg.traces.exporter,
             otel_endpoint=server_cfg.traces.otel_endpoint,
             service_name=server_cfg.traces.service_name,
+            platform_url=server_cfg.storage.platform_url,
+            platform_token=server_cfg.storage.platform_token,
         )
         self._feedback_store = create_feedback_store(
-            server_cfg.storage.backend if server_cfg.feedback.enabled else None,
+            feedback_backend,
             sqlite_path=server_cfg.storage.sqlite_path,
             database_url=server_cfg.storage.database_url,
             sqlite_connection=sqlite_conn,
+            platform_url=server_cfg.storage.platform_url,
+            platform_token=server_cfg.storage.platform_token,
         )
 
         # Initialize metrics collector.
@@ -160,10 +211,13 @@ class OpenAIChatServer:
             enabled=server_cfg.metrics.enabled,
         )
 
-        # Only run housekeeping if at least one feature has a persistent backend.
-        if server_cfg.storage.backend is not None and (
-            server_cfg.sessions.enabled or server_cfg.traces.enabled or server_cfg.feedback.enabled
-        ):
+        # Run housekeeping only if at least one *locally persistent*
+        # backend is in play.  HTTP-backed stores delegate housekeeping
+        # to the platform service.
+        local_backends = {sessions_backend, traces_backend, feedback_backend} & {
+            "sqlite", "postgres",
+        }
+        if local_backends:
             self._housekeeping_task = asyncio.create_task(self._run_housekeeping())
 
         logger.info("OpenAIChatServer: %s ready", self._agent_class.__name__)

--- a/packages/fipsagents/src/fipsagents/server/feedback.py
+++ b/packages/fipsagents/src/fipsagents/server/feedback.py
@@ -776,6 +776,8 @@ def create_feedback_store(
     sqlite_path: str = "./agent.db",
     database_url: str = "",
     sqlite_connection: Any = None,
+    platform_url: str = "",
+    platform_token: str = "",
 ) -> FeedbackStore:
     """Create a feedback store from config values."""
     if backend == "sqlite":
@@ -784,4 +786,10 @@ def create_feedback_store(
         if not database_url:
             raise ValueError("PostgresFeedbackStore requires database_url")
         return PostgresFeedbackStore(database_url)
+    elif backend == "http":
+        from .http import HttpFeedbackStore
+
+        if not platform_url:
+            raise ValueError("HttpFeedbackStore requires storage.platform_url")
+        return HttpFeedbackStore(platform_url, static_token=platform_token)
     return NullFeedbackStore()

--- a/packages/fipsagents/src/fipsagents/server/http.py
+++ b/packages/fipsagents/src/fipsagents/server/http.py
@@ -104,6 +104,7 @@ class _PlatformClient:
         *,
         static_token: str = "",
         timeout: float = 30.0,
+        transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         if not base_url:
             raise ValueError("_PlatformClient requires a base_url")
@@ -111,9 +112,15 @@ class _PlatformClient:
         # trailing slash to keep concatenation predictable.
         self._base_url = base_url.rstrip("/")
         self._static_token = static_token
-        self._client = httpx.AsyncClient(
-            base_url=self._base_url, timeout=timeout,
-        )
+        # ``transport`` is a test seam: production code never sets it,
+        # but tests inject ASGITransport (in-process platform app) or
+        # MockTransport (canned wire-shape responses).
+        kwargs: dict[str, Any] = {
+            "base_url": self._base_url, "timeout": timeout,
+        }
+        if transport is not None:
+            kwargs["transport"] = transport
+        self._client = httpx.AsyncClient(**kwargs)
 
     async def close(self) -> None:
         await self._client.aclose()
@@ -193,8 +200,16 @@ class HttpSessionStore(SessionStore):
       platform owns its own housekeeping cycle).
     """
 
-    def __init__(self, base_url: str, *, static_token: str = "") -> None:
-        self._client = _PlatformClient(base_url, static_token=static_token)
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        static_token: str = "",
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._client = _PlatformClient(
+            base_url, static_token=static_token, transport=transport,
+        )
 
     async def create(self, session_id: str | None = None) -> str:
         body: dict[str, Any] = {}
@@ -262,8 +277,16 @@ class HttpTraceStore(TraceStore):
     - ``delete_before`` → no platform endpoint; logged no-op.
     """
 
-    def __init__(self, base_url: str, *, static_token: str = "") -> None:
-        self._client = _PlatformClient(base_url, static_token=static_token)
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        static_token: str = "",
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._client = _PlatformClient(
+            base_url, static_token=static_token, transport=transport,
+        )
 
     async def save_trace(self, trace: Trace) -> None:
         # Use asdict so Span objects flatten correctly.  The platform's
@@ -365,8 +388,16 @@ class HttpFeedbackStore(FeedbackStore):
     platform — the agent's value is informational only.
     """
 
-    def __init__(self, base_url: str, *, static_token: str = "") -> None:
-        self._client = _PlatformClient(base_url, static_token=static_token)
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        static_token: str = "",
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._client = _PlatformClient(
+            base_url, static_token=static_token, transport=transport,
+        )
 
     async def add(self, record: FeedbackRecord) -> str:
         body = {

--- a/packages/fipsagents/src/fipsagents/server/http.py
+++ b/packages/fipsagents/src/fipsagents/server/http.py
@@ -1,0 +1,498 @@
+"""HTTP-backed implementations of FeedbackStore / SessionStore / TraceStore.
+
+Delegates persistence to a sibling ``fipsagents-platform`` service over
+its REST surface (`/v1/sessions`, `/v1/traces`, `/v1/feedback`).  The
+wire shape is the one documented on the platform service's OpenAPI;
+the agent imports nothing from that repo, only speaks HTTP to it.
+
+Authorization is forwarded per-request when the inbound chat request
+carried an ``Authorization: Bearer <jwt>`` header (captured by the
+server's auth-forwarding middleware into a contextvar).  When no
+per-request token is present a static ``platform_token`` from
+``StorageConfig`` is used — that's the housekeeping / service-to-service
+fallback.
+
+W3C Trace Context (``traceparent``) is forwarded verbatim from the
+inbound request when present, so the platform's writes participate in
+the same distributed trace as the chat completion that generated them.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+from dataclasses import asdict
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from .feedback import (
+    FeedbackRecord,
+    FeedbackStats,
+    FeedbackStore,
+    _compute_window_end,
+)
+from .sessions import SessionStore
+from .tracing import Span, Trace, TraceStore, TraceSummary, _summary_from_dict
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-request context (set by auth-forwarding middleware in app.py)
+# ---------------------------------------------------------------------------
+
+
+_current_authorization: ContextVar[str | None] = ContextVar(
+    "fipsagents_current_authorization", default=None,
+)
+_current_traceparent: ContextVar[str | None] = ContextVar(
+    "fipsagents_current_traceparent", default=None,
+)
+
+
+def set_request_context(
+    *, authorization: str | None, traceparent: str | None,
+) -> tuple[Any, Any]:
+    """Bind per-request authorization + traceparent to the current context.
+
+    Returns reset tokens for the caller to pass to :func:`reset_request_context`.
+    Used by ``OpenAIChatServer``'s middleware so outgoing ``Http*Store``
+    calls forward the inbound JWT and trace context.
+    """
+    auth_tok = _current_authorization.set(authorization)
+    tp_tok = _current_traceparent.set(traceparent)
+    return auth_tok, tp_tok
+
+
+def reset_request_context(tokens: tuple[Any, Any]) -> None:
+    auth_tok, tp_tok = tokens
+    _current_authorization.reset(auth_tok)
+    _current_traceparent.reset(tp_tok)
+
+
+# ---------------------------------------------------------------------------
+# PlatformError + shared client
+# ---------------------------------------------------------------------------
+
+
+class PlatformError(RuntimeError):
+    """Raised when the platform service returns an error or is unreachable.
+
+    Wraps the upstream status code and response body when available so
+    callers can distinguish transport failures from 4xx/5xx responses.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _PlatformClient:
+    """Thin httpx wrapper shared by the three Http*Store classes.
+
+    Centralises base-URL handling, bearer-token forwarding (per-request
+    contextvar > static config token) and trace-context propagation.
+    Each method maps a single HTTP call.  Connection re-use is provided
+    by the underlying ``httpx.AsyncClient``.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        static_token: str = "",
+        timeout: float = 30.0,
+    ) -> None:
+        if not base_url:
+            raise ValueError("_PlatformClient requires a base_url")
+        # httpx prefixes path with the URL's path component, so strip a
+        # trailing slash to keep concatenation predictable.
+        self._base_url = base_url.rstrip("/")
+        self._static_token = static_token
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url, timeout=timeout,
+        )
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        token = _current_authorization.get() or (
+            f"Bearer {self._static_token}" if self._static_token else None
+        )
+        if token:
+            headers["Authorization"] = token
+        traceparent = _current_traceparent.get()
+        if traceparent:
+            headers["traceparent"] = traceparent
+        return headers
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any = None,
+        params: dict[str, Any] | None = None,
+        ok_statuses: tuple[int, ...] = (200, 201),
+        not_found_returns_none: bool = False,
+    ) -> tuple[int, Any]:
+        """Send a request.  Returns (status, parsed_body_or_None).
+
+        - 2xx in ``ok_statuses`` returns the JSON body (or ``None`` for 204).
+        - 404 returns (404, None) when ``not_found_returns_none`` is True
+          so the caller can map it to ``None`` per the ABC.
+        - Any other non-OK status raises :class:`PlatformError`.
+        - Transport errors (connect refused, timeout) raise :class:`PlatformError`.
+        """
+        try:
+            resp = await self._client.request(
+                method, path, json=json, params=params, headers=self._headers(),
+            )
+        except httpx.HTTPError as exc:
+            raise PlatformError(
+                f"platform unreachable: {exc.__class__.__name__}: {exc}",
+            ) from exc
+
+        if resp.status_code in ok_statuses:
+            if resp.status_code == 204 or not resp.content:
+                return resp.status_code, None
+            return resp.status_code, resp.json()
+        if resp.status_code == 404 and not_found_returns_none:
+            return 404, None
+        # Best-effort body extraction for the error message.
+        try:
+            body = resp.text
+        except Exception:  # noqa: BLE001
+            body = "<unreadable>"
+        raise PlatformError(
+            f"platform {resp.status_code}: {body[:500]}",
+            status_code=resp.status_code,
+        )
+
+
+# ---------------------------------------------------------------------------
+# HttpSessionStore
+# ---------------------------------------------------------------------------
+
+
+class HttpSessionStore(SessionStore):
+    """SessionStore that delegates to ``fipsagents-platform``.
+
+    Maps:
+
+    - ``create``       → ``POST /v1/sessions``
+    - ``load``         → ``GET /v1/sessions/{id}``
+    - ``save``         → ``PUT /v1/sessions/{id}`` (upsert)
+    - ``exists``       → ``HEAD /v1/sessions/{id}``
+    - ``delete``       → ``DELETE /v1/sessions/{id}``
+    - ``delete_before`` → no platform endpoint; logged no-op (the
+      platform owns its own housekeeping cycle).
+    """
+
+    def __init__(self, base_url: str, *, static_token: str = "") -> None:
+        self._client = _PlatformClient(base_url, static_token=static_token)
+
+    async def create(self, session_id: str | None = None) -> str:
+        body: dict[str, Any] = {}
+        if session_id is not None:
+            body["session_id"] = session_id
+        _, data = await self._client.request("POST", "/v1/sessions", json=body)
+        return data["session_id"]
+
+    async def load(self, session_id: str) -> list[dict] | None:
+        status, data = await self._client.request(
+            "GET", f"/v1/sessions/{session_id}", not_found_returns_none=True,
+        )
+        if status == 404:
+            return None
+        return data["messages"]
+
+    async def save(self, session_id: str, messages: list[dict]) -> None:
+        await self._client.request(
+            "PUT",
+            f"/v1/sessions/{session_id}",
+            json={"messages": messages},
+        )
+
+    async def delete(self, session_id: str) -> bool:
+        status, _ = await self._client.request(
+            "DELETE",
+            f"/v1/sessions/{session_id}",
+            not_found_returns_none=True,
+        )
+        return status != 404
+
+    async def exists(self, session_id: str) -> bool:
+        # HEAD has no body and the platform returns 200 / 404.
+        status, _ = await self._client.request(
+            "HEAD",
+            f"/v1/sessions/{session_id}",
+            not_found_returns_none=True,
+        )
+        return status == 200
+
+    async def delete_before(self, cutoff: datetime) -> int:
+        logger.debug(
+            "HttpSessionStore.delete_before is a no-op; "
+            "platform owns housekeeping",
+        )
+        return 0
+
+    async def close(self) -> None:
+        await self._client.close()
+
+
+# ---------------------------------------------------------------------------
+# HttpTraceStore
+# ---------------------------------------------------------------------------
+
+
+class HttpTraceStore(TraceStore):
+    """TraceStore that delegates to ``fipsagents-platform``.
+
+    Maps:
+
+    - ``save_trace``    → ``POST /v1/traces`` (upsert)
+    - ``get_trace``     → ``GET /v1/traces/{id}``
+    - ``list_traces``   → ``GET /v1/traces?limit&offset``
+    - ``delete_before`` → no platform endpoint; logged no-op.
+    """
+
+    def __init__(self, base_url: str, *, static_token: str = "") -> None:
+        self._client = _PlatformClient(base_url, static_token=static_token)
+
+    async def save_trace(self, trace: Trace) -> None:
+        # Use asdict so Span objects flatten correctly.  The platform's
+        # TraceIn schema is a structural superset of the dataclass.
+        await self._client.request("POST", "/v1/traces", json=asdict(trace))
+
+    async def get_trace(self, trace_id: str) -> Trace | None:
+        status, data = await self._client.request(
+            "GET",
+            f"/v1/traces/{trace_id}",
+            not_found_returns_none=True,
+        )
+        if status == 404:
+            return None
+        spans = [
+            Span(
+                trace_id=s["trace_id"],
+                span_id=s["span_id"],
+                parent_span_id=s.get("parent_span_id"),
+                name=s.get("name", ""),
+                start_time=s.get("start_time", 0.0),
+                end_time=s.get("end_time"),
+                status=s.get("status", "ok"),
+                attributes=s.get("attributes", {}),
+                events=s.get("events", []),
+            )
+            for s in data.get("spans", [])
+        ]
+        return Trace(
+            trace_id=data["trace_id"],
+            started_at=data["started_at"],
+            ended_at=data.get("ended_at"),
+            model=data.get("model"),
+            session_id=data.get("session_id"),
+            status=data.get("status", "ok"),
+            spans=spans,
+        )
+
+    async def list_traces(
+        self, *, limit: int = 50, offset: int = 0,
+    ) -> list[TraceSummary]:
+        _, data = await self._client.request(
+            "GET",
+            "/v1/traces",
+            params={"limit": limit, "offset": offset},
+        )
+        return [_summary_from_dict(d) for d in data]
+
+    async def delete_before(self, cutoff: datetime) -> int:
+        logger.debug(
+            "HttpTraceStore.delete_before is a no-op; "
+            "platform owns housekeeping",
+        )
+        return 0
+
+    async def close(self) -> None:
+        await self._client.close()
+
+
+# ---------------------------------------------------------------------------
+# HttpFeedbackStore
+# ---------------------------------------------------------------------------
+
+
+def _record_from_dict(d: dict[str, Any]) -> FeedbackRecord:
+    return FeedbackRecord(
+        feedback_id=d["feedback_id"],
+        trace_id=d["trace_id"],
+        session_id=d.get("session_id"),
+        rating=d["rating"],
+        comment=d.get("comment"),
+        correction=d.get("correction"),
+        model_id=d.get("model_id"),
+        latency_ms=d.get("latency_ms"),
+        turn_index=d.get("turn_index"),
+        agent_type=d.get("agent_type"),
+        created_at=d["created_at"],
+        user_id=d.get("user_id", "anonymous"),
+    )
+
+
+class HttpFeedbackStore(FeedbackStore):
+    """FeedbackStore that delegates to ``fipsagents-platform``.
+
+    Maps:
+
+    - ``add``           → ``POST /v1/feedback``
+    - ``get``           → ``GET /v1/feedback/{id}``
+    - ``query``         → ``GET /v1/feedback`` (filter via query params)
+    - ``stats``         → ``GET /v1/feedback/stats``
+    - ``update``        → ``PATCH /v1/feedback/{id}``
+    - ``delete_before`` → no platform endpoint; logged no-op.
+
+    Note on identity: the platform's ``POST /v1/feedback`` always
+    generates a fresh ``feedback_id`` and ``created_at`` server-side.
+    Any values on the inbound :class:`FeedbackRecord` are discarded and
+    replaced with the platform's authoritative copies.  Likewise
+    ``user_id`` is set from the gateway-issued bearer subject by the
+    platform — the agent's value is informational only.
+    """
+
+    def __init__(self, base_url: str, *, static_token: str = "") -> None:
+        self._client = _PlatformClient(base_url, static_token=static_token)
+
+    async def add(self, record: FeedbackRecord) -> str:
+        body = {
+            "rating": record.rating,
+            "trace_id": record.trace_id,
+            "session_id": record.session_id,
+            "comment": record.comment,
+            "correction": record.correction,
+            "model_id": record.model_id,
+            "latency_ms": record.latency_ms,
+            "turn_index": record.turn_index,
+            "agent_type": record.agent_type,
+        }
+        _, data = await self._client.request(
+            "POST",
+            "/v1/feedback",
+            json={k: v for k, v in body.items() if v is not None},
+        )
+        return data["feedback_id"]
+
+    async def get(self, feedback_id: str) -> FeedbackRecord | None:
+        status, data = await self._client.request(
+            "GET",
+            f"/v1/feedback/{feedback_id}",
+            not_found_returns_none=True,
+        )
+        if status == 404:
+            return None
+        return _record_from_dict(data)
+
+    async def query(
+        self,
+        *,
+        trace_id: str | None = None,
+        session_id: str | None = None,
+        user_id: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[FeedbackRecord]:
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if trace_id is not None:
+            params["trace_id"] = trace_id
+        if session_id is not None:
+            params["session_id"] = session_id
+        if user_id is not None:
+            params["user_id"] = user_id
+        if since is not None:
+            params["since"] = since.isoformat()
+        if until is not None:
+            params["until"] = until.isoformat()
+        _, data = await self._client.request(
+            "GET", "/v1/feedback", params=params,
+        )
+        return [_record_from_dict(d) for d in data]
+
+    async def stats(
+        self,
+        *,
+        window: str = "day",
+        agent_type: str | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> list[FeedbackStats]:
+        params: dict[str, Any] = {"window": window}
+        if agent_type is not None:
+            params["agent_type"] = agent_type
+        if since is not None:
+            params["since"] = since.isoformat()
+        if until is not None:
+            params["until"] = until.isoformat()
+        _, data = await self._client.request(
+            "GET", "/v1/feedback/stats", params=params,
+        )
+        return [
+            FeedbackStats(
+                window_start=row["window_start"],
+                # Platform may return window_end already computed; if
+                # absent, derive it locally so the caller sees the same
+                # shape as the SQLite/Postgres backends.
+                window_end=row.get(
+                    "window_end",
+                    _compute_window_end(row["window_start"], window),
+                ),
+                agent_type=row.get("agent_type"),
+                thumbs_up=row["thumbs_up"],
+                thumbs_down=row["thumbs_down"],
+                total=row["total"],
+            )
+            for row in data
+        ]
+
+    async def update(
+        self,
+        feedback_id: str,
+        *,
+        rating: int | None = None,
+        comment: str | None = None,
+        correction: str | None = None,
+    ) -> FeedbackRecord | None:
+        body: dict[str, Any] = {}
+        if rating is not None:
+            body["rating"] = rating
+        if comment is not None:
+            body["comment"] = comment
+        if correction is not None:
+            body["correction"] = correction
+        if not body:
+            return await self.get(feedback_id)
+        status, data = await self._client.request(
+            "PATCH",
+            f"/v1/feedback/{feedback_id}",
+            json=body,
+            not_found_returns_none=True,
+        )
+        if status == 404:
+            return None
+        return _record_from_dict(data)
+
+    async def delete_before(self, cutoff: datetime) -> int:
+        logger.debug(
+            "HttpFeedbackStore.delete_before is a no-op; "
+            "platform owns housekeeping",
+        )
+        return 0
+
+    async def close(self) -> None:
+        await self._client.close()

--- a/packages/fipsagents/src/fipsagents/server/sessions.py
+++ b/packages/fipsagents/src/fipsagents/server/sessions.py
@@ -313,6 +313,8 @@ def create_session_store(
     sqlite_path: str = "./agent.db",
     database_url: str = "",
     sqlite_connection: Any = None,
+    platform_url: str = "",
+    platform_token: str = "",
 ) -> SessionStore:
     """Create a session store from config values."""
     if backend == "sqlite":
@@ -321,4 +323,10 @@ def create_session_store(
         if not database_url:
             raise ValueError("PostgresSessionStore requires database_url")
         return PostgresSessionStore(database_url)
+    elif backend == "http":
+        from .http import HttpSessionStore
+
+        if not platform_url:
+            raise ValueError("HttpSessionStore requires storage.platform_url")
+        return HttpSessionStore(platform_url, static_token=platform_token)
     return NullSessionStore()

--- a/packages/fipsagents/src/fipsagents/server/tracing.py
+++ b/packages/fipsagents/src/fipsagents/server/tracing.py
@@ -511,6 +511,8 @@ def create_trace_store(
     exporter: str | None = None,
     otel_endpoint: str | None = None,
     service_name: str = "fipsagents",
+    platform_url: str = "",
+    platform_token: str = "",
 ) -> TraceStore:
     """Create a trace store from config values."""
     if backend == "sqlite":
@@ -519,6 +521,12 @@ def create_trace_store(
         if not database_url:
             raise ValueError("PostgresTraceStore requires database_url")
         inner = PostgresTraceStore(database_url)
+    elif backend == "http":
+        from .http import HttpTraceStore
+
+        if not platform_url:
+            raise ValueError("HttpTraceStore requires storage.platform_url")
+        inner = HttpTraceStore(platform_url, static_token=platform_token)
     else:
         inner = NullTraceStore()
 

--- a/packages/fipsagents/tests/test_http_stores.py
+++ b/packages/fipsagents/tests/test_http_stores.py
@@ -1,0 +1,480 @@
+"""Unit tests for the Http*Store implementations.
+
+Uses ``httpx.MockTransport`` to drive each store against a recorded
+wire shape — verifies request method/path/body/params/headers without
+needing a real platform service. End-to-end coverage against the live
+platform app lives in ``test_http_stores_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+
+from fipsagents.server.feedback import FeedbackRecord
+from fipsagents.server.http import (
+    HttpFeedbackStore,
+    HttpSessionStore,
+    HttpTraceStore,
+    PlatformError,
+    reset_request_context,
+    set_request_context,
+)
+from fipsagents.server.tracing import Span, Trace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Collects every request the transport sees, returns canned responses."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        self._responses = list(responses)
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if not self._responses:
+            return httpx.Response(500, json={"detail": "no canned response"})
+        return self._responses.pop(0)
+
+
+def _ok(status: int, body: Any = None) -> httpx.Response:
+    if body is None:
+        return httpx.Response(status)
+    return httpx.Response(status, json=body)
+
+
+# ---------------------------------------------------------------------------
+# HttpSessionStore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_create_posts_and_returns_id() -> None:
+    rec = _Recorder([_ok(201, {"session_id": "sess_abc"})])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    sid = await store.create("sess_abc")
+    assert sid == "sess_abc"
+    assert rec.requests[0].method == "POST"
+    assert rec.requests[0].url.path == "/v1/sessions"
+    assert json.loads(rec.requests[0].content) == {"session_id": "sess_abc"}
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_create_omits_id_when_none() -> None:
+    rec = _Recorder([_ok(201, {"session_id": "sess_gen"})])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    sid = await store.create()
+    assert sid == "sess_gen"
+    assert json.loads(rec.requests[0].content) == {}
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_load_returns_messages() -> None:
+    rec = _Recorder([
+        _ok(200, {"session_id": "sess_1", "messages": [{"role": "user", "content": "hi"}]}),
+    ])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    msgs = await store.load("sess_1")
+    assert msgs == [{"role": "user", "content": "hi"}]
+    assert rec.requests[0].method == "GET"
+    assert rec.requests[0].url.path == "/v1/sessions/sess_1"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_load_404_returns_none() -> None:
+    rec = _Recorder([_ok(404, {"detail": "not found"})])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    assert await store.load("missing") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_save_puts_messages() -> None:
+    rec = _Recorder([_ok(200, {"session_id": "sess_1", "saved": True})])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    await store.save("sess_1", [{"role": "user", "content": "hi"}])
+    assert rec.requests[0].method == "PUT"
+    assert rec.requests[0].url.path == "/v1/sessions/sess_1"
+    assert json.loads(rec.requests[0].content) == {
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_exists_uses_HEAD() -> None:
+    rec = _Recorder([_ok(200), _ok(404)])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    assert await store.exists("sess_1") is True
+    assert await store.exists("missing") is False
+    assert rec.requests[0].method == "HEAD"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_delete_returns_existed_flag() -> None:
+    rec = _Recorder([_ok(200, {"deleted": True}), _ok(404)])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    assert await store.delete("sess_1") is True
+    assert await store.delete("missing") is False
+    assert rec.requests[0].method == "DELETE"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_delete_before_is_noop() -> None:
+    rec = _Recorder([])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    deleted = await store.delete_before(datetime.now(timezone.utc))
+    assert deleted == 0
+    assert rec.requests == []  # no HTTP call made
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# HttpTraceStore
+# ---------------------------------------------------------------------------
+
+
+def _trace(trace_id: str = "trace_x") -> Trace:
+    return Trace(
+        trace_id=trace_id,
+        started_at="2026-04-27T12:00:00+00:00",
+        ended_at="2026-04-27T12:00:01+00:00",
+        model="test-model",
+        session_id="sess_1",
+        status="ok",
+        spans=[
+            Span(
+                trace_id=trace_id,
+                span_id="s1",
+                name="request",
+                start_time=0.0,
+                end_time=1.0,
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_trace_save_posts_full_payload() -> None:
+    rec = _Recorder([_ok(201, {"trace_id": "trace_x", "saved": True})])
+    store = HttpTraceStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    await store.save_trace(_trace())
+    assert rec.requests[0].method == "POST"
+    assert rec.requests[0].url.path == "/v1/traces"
+    body = json.loads(rec.requests[0].content)
+    assert body["trace_id"] == "trace_x"
+    assert body["model"] == "test-model"
+    assert len(body["spans"]) == 1
+    assert body["spans"][0]["span_id"] == "s1"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_trace_get_returns_trace_with_spans() -> None:
+    payload = {
+        "trace_id": "trace_x",
+        "started_at": "2026-04-27T12:00:00+00:00",
+        "ended_at": "2026-04-27T12:00:01+00:00",
+        "model": "test-model",
+        "session_id": "sess_1",
+        "status": "ok",
+        "spans": [
+            {
+                "trace_id": "trace_x", "span_id": "s1", "parent_span_id": None,
+                "name": "request", "start_time": 0.0, "end_time": 1.0,
+                "status": "ok", "attributes": {}, "events": [],
+            },
+        ],
+    }
+    rec = _Recorder([_ok(200, payload)])
+    store = HttpTraceStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    trace = await store.get_trace("trace_x")
+    assert trace is not None
+    assert trace.trace_id == "trace_x"
+    assert len(trace.spans) == 1
+    assert trace.spans[0].name == "request"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_trace_get_404_returns_none() -> None:
+    rec = _Recorder([_ok(404, {"detail": "not found"})])
+    store = HttpTraceStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    assert await store.get_trace("missing") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_trace_list_passes_pagination_params() -> None:
+    rec = _Recorder([_ok(200, [])])
+    store = HttpTraceStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    await store.list_traces(limit=25, offset=50)
+    url = rec.requests[0].url
+    assert url.path == "/v1/traces"
+    assert url.params["limit"] == "25"
+    assert url.params["offset"] == "50"
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# HttpFeedbackStore
+# ---------------------------------------------------------------------------
+
+
+def _record(feedback_id: str = "fb_local") -> FeedbackRecord:
+    return FeedbackRecord(
+        feedback_id=feedback_id,
+        trace_id="trace_x",
+        session_id="sess_1",
+        rating=1,
+        comment="nice",
+        correction=None,
+        model_id="test-model",
+        latency_ms=12.5,
+        turn_index=0,
+        agent_type="calculus",
+        created_at="2026-04-27T12:00:00+00:00",
+        user_id="anonymous",
+    )
+
+
+@pytest.mark.asyncio
+async def test_feedback_add_returns_platform_id_not_local() -> None:
+    """Platform regenerates feedback_id; local id is intentionally discarded."""
+    rec = _Recorder([_ok(201, {"feedback_id": "fb_remote"})])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    returned = await store.add(_record(feedback_id="fb_local"))
+    assert returned == "fb_remote"
+    body = json.loads(rec.requests[0].content)
+    # Local feedback_id and created_at are NOT sent — the platform owns them.
+    assert "feedback_id" not in body
+    assert "created_at" not in body
+    assert body["rating"] == 1
+    assert body["trace_id"] == "trace_x"
+    assert body["agent_type"] == "calculus"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_get_returns_record() -> None:
+    payload = {
+        "feedback_id": "fb_1", "trace_id": "trace_x", "session_id": "sess_1",
+        "rating": -1, "comment": "no", "correction": None,
+        "model_id": None, "latency_ms": None, "turn_index": None,
+        "agent_type": None, "created_at": "2026-04-27T12:00:00+00:00",
+        "user_id": "user-7",
+    }
+    rec = _Recorder([_ok(200, payload)])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    record = await store.get("fb_1")
+    assert record is not None
+    assert record.user_id == "user-7"
+    assert record.rating == -1
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_query_passes_filters() -> None:
+    rec = _Recorder([_ok(200, [])])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    since = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    await store.query(
+        trace_id="trace_x", user_id="user-7",
+        since=since, limit=10, offset=20,
+    )
+    params = rec.requests[0].url.params
+    assert params["trace_id"] == "trace_x"
+    assert params["user_id"] == "user-7"
+    assert params["since"] == since.isoformat()
+    assert params["limit"] == "10"
+    assert params["offset"] == "20"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_stats_passes_window() -> None:
+    rec = _Recorder([_ok(200, [
+        {
+            "window_start": "2026-04-27T00:00:00+00:00",
+            "window_end": "2026-04-28T00:00:00+00:00",
+            "agent_type": "calculus",
+            "thumbs_up": 3, "thumbs_down": 1, "total": 4,
+        },
+    ])])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    stats = await store.stats(window="day", agent_type="calculus")
+    assert len(stats) == 1
+    assert stats[0].thumbs_up == 3
+    assert rec.requests[0].url.params["window"] == "day"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_update_omits_unchanged_fields() -> None:
+    payload = {
+        "feedback_id": "fb_1", "trace_id": "trace_x", "session_id": None,
+        "rating": -1, "comment": "updated", "correction": None,
+        "model_id": None, "latency_ms": None, "turn_index": None,
+        "agent_type": None, "created_at": "2026-04-27T12:00:00+00:00",
+        "user_id": "anonymous",
+    }
+    rec = _Recorder([_ok(200, payload)])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    record = await store.update("fb_1", comment="updated")
+    assert record is not None
+    body = json.loads(rec.requests[0].content)
+    assert body == {"comment": "updated"}  # rating, correction omitted
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_update_404_returns_none() -> None:
+    rec = _Recorder([_ok(404, {"detail": "not found"})])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    assert await store.update("missing", rating=1) is None
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Auth + traceparent forwarding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_request_authorization_overrides_static_token() -> None:
+    rec = _Recorder([_ok(201, {"session_id": "s"})])
+    store = HttpSessionStore(
+        "http://platform.test",
+        static_token="static-secret",
+        transport=httpx.MockTransport(rec),
+    )
+    tokens = set_request_context(
+        authorization="Bearer per-request-jwt",
+        traceparent="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+    )
+    try:
+        await store.create("s")
+    finally:
+        reset_request_context(tokens)
+    assert rec.requests[0].headers["authorization"] == "Bearer per-request-jwt"
+    assert rec.requests[0].headers["traceparent"].startswith("00-")
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_static_token_used_when_no_request_context() -> None:
+    rec = _Recorder([_ok(201, {"session_id": "s"})])
+    store = HttpSessionStore(
+        "http://platform.test",
+        static_token="static-secret",
+        transport=httpx.MockTransport(rec),
+    )
+    await store.create("s")
+    assert rec.requests[0].headers["authorization"] == "Bearer static-secret"
+    assert "traceparent" not in rec.requests[0].headers
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_no_auth_header_when_unconfigured() -> None:
+    rec = _Recorder([_ok(201, {"session_id": "s"})])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    await store.create("s")
+    assert "authorization" not in rec.requests[0].headers
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_5xx_raises_platform_error_with_status() -> None:
+    rec = _Recorder([httpx.Response(503, json={"detail": "down"})])
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    with pytest.raises(PlatformError) as exc_info:
+        await store.create("s")
+    assert exc_info.value.status_code == 503
+    assert "503" in str(exc_info.value)
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_transport_error_raises_platform_error() -> None:
+    def _explode(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+    store = HttpSessionStore(
+        "http://platform.test", transport=httpx.MockTransport(_explode),
+    )
+    with pytest.raises(PlatformError) as exc_info:
+        await store.create("s")
+    assert exc_info.value.status_code is None
+    assert "unreachable" in str(exc_info.value).lower()
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_4xx_other_than_404_raises() -> None:
+    rec = _Recorder([httpx.Response(401, json={"detail": "unauthorized"})])
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=httpx.MockTransport(rec),
+    )
+    with pytest.raises(PlatformError) as exc_info:
+        await store.add(_record())
+    assert exc_info.value.status_code == 401
+    await store.close()

--- a/packages/fipsagents/tests/test_http_stores_e2e.py
+++ b/packages/fipsagents/tests/test_http_stores_e2e.py
@@ -1,0 +1,337 @@
+"""End-to-end tests for the Http*Store implementations.
+
+Boots the real ``fipsagents_platform`` ASGI app in-process against a
+fresh SQLite-backed store and points the agent-side ``Http*Store`` at
+it via ``httpx.ASGITransport``.  Verifies the full ABC surface
+round-trips through the REST veneer with no mocks.
+
+Skipped automatically when ``fipsagents_platform`` is not installed —
+the suite is opt-in and only runs when the sibling repo is checked out
+and pip-installed (eg via ``pip install -e ../../fipsagents-platform``).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import httpx
+import pytest
+
+pytest.importorskip(
+    "fipsagents_platform",
+    reason="fipsagents_platform not installed — pip install the sibling "
+    "repo to exercise the e2e suite.",
+)
+
+from fipsagents.server.feedback import FeedbackRecord
+from fipsagents.server.http import (
+    HttpFeedbackStore,
+    HttpSessionStore,
+    HttpTraceStore,
+)
+from fipsagents.server.tracing import Span, Trace
+
+
+@pytest.fixture
+def platform_db(monkeypatch: pytest.MonkeyPatch):
+    fd, path = tempfile.mkstemp(prefix="e2e-platform-", suffix=".db")
+    os.close(fd)
+    os.unlink(path)
+    monkeypatch.setenv("PLATFORM_BACKEND", "sqlite")
+    monkeypatch.setenv("PLATFORM_SQLITE_PATH", path)
+    monkeypatch.setenv("PLATFORM_AUTH_MODE", "none")
+    from fipsagents_platform.config import reset_settings_for_tests
+
+    reset_settings_for_tests()
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+@pytest.fixture
+async def platform_transport(platform_db):
+    """Yield an ASGITransport bound to the platform app, with lifespan running."""
+    from fipsagents_platform.app import create_app
+
+    app = create_app()
+    async with app.router.lifespan_context(app):
+        yield httpx.ASGITransport(app=app)
+
+
+# ---------------------------------------------------------------------------
+# Sessions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_full_lifecycle(platform_transport) -> None:
+    store = HttpSessionStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    sid = await store.create()
+    assert sid.startswith("sess_")
+
+    assert await store.exists(sid) is True
+    assert await store.load(sid) == []
+
+    await store.save(sid, [{"role": "user", "content": "hello"}])
+    msgs = await store.load(sid)
+    assert msgs == [{"role": "user", "content": "hello"}]
+
+    # Save again to verify upsert semantics.
+    await store.save(sid, [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ])
+    assert len(await store.load(sid)) == 2
+
+    assert await store.delete(sid) is True
+    assert await store.exists(sid) is False
+    assert await store.load(sid) is None
+    assert await store.delete(sid) is False
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_create_with_explicit_id(platform_transport) -> None:
+    store = HttpSessionStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    sid = await store.create("sess_e2e_explicit")
+    assert sid == "sess_e2e_explicit"
+    assert await store.exists(sid) is True
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_session_save_creates_when_missing(platform_transport) -> None:
+    """PUT /v1/sessions/{id} upserts — verifies HttpSessionStore.save() works
+    against a session that was never explicitly created."""
+    store = HttpSessionStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    await store.save("sess_e2e_upsert", [{"role": "user", "content": "x"}])
+    assert await store.exists("sess_e2e_upsert") is True
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Traces
+# ---------------------------------------------------------------------------
+
+
+def _trace(trace_id: str) -> Trace:
+    return Trace(
+        trace_id=trace_id,
+        started_at="2026-04-27T12:00:00+00:00",
+        ended_at="2026-04-27T12:00:01+00:00",
+        model="test-model",
+        session_id="sess_e2e",
+        status="ok",
+        spans=[
+            Span(
+                trace_id=trace_id, span_id="root",
+                name="request", start_time=0.0, end_time=1.0,
+                attributes={"prompt_tokens": 10, "completion_tokens": 5},
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_trace_save_and_get_roundtrip(platform_transport) -> None:
+    store = HttpTraceStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    await store.save_trace(_trace("trace_e2e_1"))
+    fetched = await store.get_trace("trace_e2e_1")
+    assert fetched is not None
+    assert fetched.model == "test-model"
+    assert len(fetched.spans) == 1
+    assert fetched.spans[0].span_id == "root"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_trace_get_missing_returns_none(platform_transport) -> None:
+    store = HttpTraceStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    assert await store.get_trace("trace_does_not_exist") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_trace_list_paginates(platform_transport) -> None:
+    store = HttpTraceStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    for i in range(5):
+        await store.save_trace(_trace(f"trace_e2e_list_{i}"))
+
+    page1 = await store.list_traces(limit=2, offset=0)
+    page2 = await store.list_traces(limit=2, offset=2)
+    assert len(page1) == 2
+    assert len(page2) == 2
+    # No overlap between pages.
+    ids1 = {s.trace_id for s in page1}
+    ids2 = {s.trace_id for s in page2}
+    assert ids1.isdisjoint(ids2)
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_trace_save_upserts(platform_transport) -> None:
+    store = HttpTraceStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    t1 = _trace("trace_e2e_upsert")
+    await store.save_trace(t1)
+    t1.status = "error"
+    await store.save_trace(t1)
+    fetched = await store.get_trace("trace_e2e_upsert")
+    assert fetched is not None
+    assert fetched.status == "error"
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Feedback
+# ---------------------------------------------------------------------------
+
+
+def _record() -> FeedbackRecord:
+    return FeedbackRecord(
+        feedback_id="fb_local_ignored",  # platform regenerates
+        trace_id="trace_e2e_fb",
+        session_id="sess_e2e",
+        rating=1,
+        comment="great",
+        correction=None,
+        model_id="test-model",
+        latency_ms=12.5,
+        turn_index=0,
+        agent_type="calculus",
+        created_at="2026-04-27T12:00:00+00:00",
+        user_id="anonymous",  # platform overwrites with bearer subject
+    )
+
+
+@pytest.mark.asyncio
+async def test_feedback_add_and_get(platform_transport) -> None:
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    fb_id = await store.add(_record())
+    assert fb_id.startswith("fb_")
+    assert fb_id != "fb_local_ignored"  # platform-generated
+    fetched = await store.get(fb_id)
+    assert fetched is not None
+    assert fetched.feedback_id == fb_id
+    assert fetched.rating == 1
+    assert fetched.comment == "great"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_get_missing_returns_none(platform_transport) -> None:
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    assert await store.get("fb_does_not_exist") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_query_filters(platform_transport) -> None:
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    rec_a = _record()
+    rec_a.trace_id = "trace_filter_a"
+    rec_b = _record()
+    rec_b.trace_id = "trace_filter_b"
+    await store.add(rec_a)
+    await store.add(rec_a)
+    await store.add(rec_b)
+
+    matches = await store.query(trace_id="trace_filter_a")
+    assert len(matches) == 2
+    assert all(m.trace_id == "trace_filter_a" for m in matches)
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_update(platform_transport) -> None:
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    fb_id = await store.add(_record())
+    updated = await store.update(fb_id, comment="updated")
+    assert updated is not None
+    assert updated.comment == "updated"
+    assert updated.rating == 1  # rating unchanged
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_update_missing_returns_none(platform_transport) -> None:
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    assert await store.update("fb_missing", comment="x") is None
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_feedback_stats_aggregates(platform_transport) -> None:
+    store = HttpFeedbackStore(
+        "http://platform.test", transport=platform_transport,
+    )
+    up = _record()
+    up.trace_id = "trace_stats"
+    up.rating = 1
+    down = _record()
+    down.trace_id = "trace_stats"
+    down.rating = -1
+    for _ in range(3):
+        await store.add(up)
+    await store.add(down)
+
+    stats = await store.stats(window="day", agent_type="calculus")
+    assert len(stats) >= 1
+    bucket = stats[-1]
+    assert bucket.thumbs_up >= 3
+    assert bucket.thumbs_down >= 1
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# delete_before is intentionally a no-op against the platform.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_http_stores_delete_before_is_noop(platform_transport) -> None:
+    from datetime import datetime, timezone
+
+    far_future = datetime.now(timezone.utc).replace(year=2099)
+    sess = HttpSessionStore("http://platform.test", transport=platform_transport)
+    trc = HttpTraceStore("http://platform.test", transport=platform_transport)
+    fb = HttpFeedbackStore("http://platform.test", transport=platform_transport)
+    try:
+        # Seed something the platform would otherwise sweep.
+        sid = await sess.create("sess_noop_check")
+        await fb.add(_record())
+
+        assert await sess.delete_before(far_future) == 0
+        assert await trc.delete_before(far_future) == 0
+        assert await fb.delete_before(far_future) == 0
+
+        # Data still present.
+        assert await sess.exists(sid) is True
+    finally:
+        await sess.close()
+        await trc.close()
+        await fb.close()

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -61,10 +61,13 @@ class _StubAgent(BaseAgent):
                     backend=None,
                     sqlite_path="./agent.db",
                     database_url="",
+                    platform_url="",
+                    platform_token="",
                 ),
                 sessions=types.SimpleNamespace(
                     enabled=False,
                     max_age_hours=168,
+                    backend=None,
                 ),
                 traces=types.SimpleNamespace(
                     enabled=False,
@@ -73,6 +76,7 @@ class _StubAgent(BaseAgent):
                     exporter=None,
                     otel_endpoint=None,
                     service_name="fipsagents",
+                    backend=None,
                 ),
                 metrics=types.SimpleNamespace(
                     enabled=False,
@@ -80,6 +84,7 @@ class _StubAgent(BaseAgent):
                 feedback=types.SimpleNamespace(
                     enabled=False,
                     max_age_hours=720,
+                    backend=None,
                 ),
             ),
         )
@@ -661,10 +666,13 @@ def _build_server_with_feedback(tmp_path) -> OpenAIChatServer:
                 backend="sqlite",
                 sqlite_path=db_path,
                 database_url="",
+                platform_url="",
+                platform_token="",
             )
             self.config.server.feedback = types.SimpleNamespace(
                 enabled=True,
                 max_age_hours=0,
+                backend=None,
             )
 
     return OpenAIChatServer(_A)


### PR DESCRIPTION
## Summary

Closes #114. Implements the agent-side half of the Cross-Agent Platform Service decision from #112: three drop-in HTTP-backed implementations of the v0.12.0 store ABCs that delegate persistence to a sibling [`fipsagents-platform`](https://github.com/fips-agents/fipsagents-platform) service. Also bumps `fipsagents` to `0.13.0`.

- **`HttpSessionStore`, `HttpTraceStore`, `HttpFeedbackStore`** in `fipsagents.server.http`. Same ABC signatures as the SQLite/Postgres backends; transport is a thin `httpx.AsyncClient` wrapper around the platform's REST surface (`/v1/sessions`, `/v1/traces`, `/v1/feedback`).
- **Per-store backend override** — `SessionsConfig` / `TracesConfig` / `FeedbackConfig` each gain an optional `backend: sqlite | postgres | http` field. Lets an operator route, eg, `feedback.backend: http` while keeping sessions/traces on local SQLite.
- **Platform routing config** — `StorageConfig` gains `platform_url` and `platform_token`. Static token is the service-to-service / housekeeping fallback; per-request `Authorization` headers from inbound chat requests take precedence and are forwarded via a contextvar populated by a new `_HttpStoreContextMiddleware`. W3C `traceparent` is forwarded the same way so platform writes participate in the same distributed trace.
- **`platform-client` extra** — opt-in documentation marker for HTTP-backed deployments.

### Two design points worth noting

1. `delete_before()` on every `Http*Store` is a logged no-op — the platform owns its own housekeeping cycle, so the agent should never be deleting cross-tenant data over the wire. `OpenAIChatServer._lifespan` skips the housekeeping task entirely when every active store is HTTP-backed.
2. `HttpFeedbackStore.add()` returns the platform-generated `feedback_id`; the agent's pre-generated id and `created_at` on the inbound `FeedbackRecord` are intentionally discarded (matches the platform's `POST /v1/feedback` contract). Documented in the docstring.

## Test plan

- [x] 24 unit tests with `httpx.MockTransport` covering wire shape, auth/traceparent forwarding precedence, and failure modes (5xx, connect-refused, 4xx-other-than-404 → `PlatformError` with upstream status code).
- [x] 14 end-to-end tests booting the real `fipsagents_platform` ASGI app in-process against fresh SQLite — full ABC surface for all three stores, opt-in via `pytest.importorskip`.
- [x] Full unit suite still green: 734 passed in `packages/fipsagents/tests/` (excluding pre-existing external integration tests).
- [x] `gitleaks detect` clean.
- [ ] After merge: tag `fipsagents-v0.13.0` to fire the existing PyPI publish workflow.

## Commits

```
3b5c579 feat(server): add per-store backend override and platform fields in StorageConfig
0dcee4e feat(server): add HttpSessionStore, HttpTraceStore, HttpFeedbackStore
23a1801 feat(server): wire http backends and Authorization forwarding in OpenAIChatServer
f3ed039 test(server): unit + e2e coverage for Http*Store
2bc2727 chore(fipsagents): bump to 0.13.0 and document Http*Store release
```

Refs #112 (architecture decision), #114 (this implementation).