### PR TITLE
feat(server): tenant_id + session_id labels on agent_tokens_total

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,14 +259,21 @@ Query endpoints: `GET /v1/traces`, `GET /v1/traces/{id}`. Sampling rate is confi
 - `agent_request_duration_seconds` -- end-to-end request latency histogram
 - `agent_model_call_duration_seconds` -- per-model-call latency histogram
 - `agent_tool_call_total` -- tool invocation count by tool name
-- `agent_tokens_total` -- token consumption by direction (prompt/completion)
+- `agent_tokens_total` -- token consumption by direction (prompt/completion); optional `tenant_id` and `session_id` label dimensions controlled by `metrics.token_label_mode`
 
 Exposed at `GET /metrics` in Prometheus text format. Requires the `[metrics]` optional extra (`prometheus_client`). When metrics are disabled, `NullMetricsCollector` is a silent no-op.
+
+`token_label_mode` selects which dimensions are attached to `agent_tokens_total`. Each step up adds one label at the cost of more time-series stored by Prometheus:
+
+- `model` (default) — only `model` and `direction`. Bounded by the model catalog.
+- `tenant` — also adds `tenant_id` (gateway-stamped via the `X-Tenant` header; missing-header default is `"default"`). Suitable for most enterprise deployments.
+- `session` — also adds `session_id`. **High cardinality**: one time-series per session per direction per model. Only enable when an external aggregation step (Prometheus federation, Mimir) can absorb the volume; otherwise prefer `GET /v1/sessions/{id}/usage` for per-session totals.
 
 ```yaml
 server:
   metrics:
     enabled: true
+    token_label_mode: tenant  # or "model" (default), or "session"
 ```
 
 ```toml

--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -438,9 +438,26 @@ class TracesConfig(_PerStoreBackendMixin):
 
 
 class MetricsConfig(BaseModel):
-    """Prometheus metrics settings."""
+    """Prometheus metrics settings.
+
+    ``token_label_mode`` controls the label cardinality of
+    ``agent_tokens_total``.  Each step up adds one dimension at the cost
+    of more time-series stored by Prometheus.
+
+    - ``model`` (default) — current behaviour, only ``model`` and
+      ``direction`` labels.  Bounded by the model catalog.
+    - ``tenant`` — also adds ``tenant_id`` (typically gateway-stamped via
+      the ``X-Tenant`` header). Bounded by the tenant count, suitable for
+      most enterprise deployments.
+    - ``session`` — also adds ``session_id``.  **High cardinality**: one
+      time-series per session per direction per model.  Only enable when
+      you have an external aggregation step (eg Prometheus federation,
+      Mimir) that can absorb the volume; otherwise prefer
+      ``GET /v1/sessions/{id}/usage`` for per-session totals.
+    """
 
     enabled: bool = False
+    token_label_mode: Literal["model", "tenant", "session"] = "model"
 
 
 class FeedbackConfig(_PerStoreBackendMixin):

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -209,6 +209,7 @@ class OpenAIChatServer:
         # Initialize metrics collector.
         self._metrics_collector = create_metrics_collector(
             enabled=server_cfg.metrics.enabled,
+            token_label_mode=server_cfg.metrics.token_label_mode,
         )
 
         # Run housekeeping only if at least one *locally persistent*
@@ -571,6 +572,10 @@ class OpenAIChatServer:
         model_name = req.model or agent.config.model.name
         incoming = _messages_to_dicts(req.messages)
         overrides = _extract_overrides(req)
+        # Tenant identity is gateway-stamped; default to "default" so
+        # the metrics label space stays bounded when running without a
+        # gateway in front (local dev, smoke tests).
+        tenant_id = request.headers.get("X-Tenant") or "default"
 
         # Session: load prior messages if session_id provided.
         if req.session_id and self._session_store:
@@ -614,6 +619,7 @@ class OpenAIChatServer:
             content, metrics, finish_reason = await self._collect_sync(
                 agent, incoming, model_name=model_name,
                 overrides=overrides, collector=collector,
+                tenant_id=tenant_id, session_id=req.session_id,
             )
             # Session: save after sync response.
             if req.session_id and self._session_store:
@@ -642,6 +648,7 @@ class OpenAIChatServer:
                 incoming, model_name, overrides=overrides,
                 session_id=req.session_id, collector=collector,
                 metrics_start=metrics_start, trace_id=trace_id,
+                tenant_id=tenant_id,
             ),
             media_type="text/event-stream",
             headers={
@@ -662,6 +669,8 @@ class OpenAIChatServer:
         model_name: str = "",
         overrides: dict[str, Any] | None = None,
         collector: TraceCollector | None = None,
+        tenant_id: str | None = None,
+        session_id: str | None = None,
     ) -> tuple[str, StreamMetrics | None, str]:
         """Drive ``astep_stream`` for a non-streaming response.
 
@@ -681,7 +690,10 @@ class OpenAIChatServer:
             events = agent.astep_stream(max_iterations=10, **(overrides or {}))
             if self._metrics_collector is not None:
                 events = self._metrics_collector.observe(
-                    events, model=model_name,
+                    events,
+                    model=model_name,
+                    tenant_id=tenant_id,
+                    session_id=session_id,
                 )
             if collector:
                 events = collector.observe(events)
@@ -727,6 +739,7 @@ class OpenAIChatServer:
         collector: TraceCollector | None = None,
         metrics_start: float | None = None,
         trace_id: str | None = None,
+        tenant_id: str | None = None,
     ) -> AsyncIterator[str]:
         """Drive the agent's event stream, serialising to OpenAI SSE chunks.
 
@@ -745,7 +758,10 @@ class OpenAIChatServer:
                 events = self._agent.astep_stream(max_iterations=10, **(overrides or {}))
                 if self._metrics_collector is not None:
                     events = self._metrics_collector.observe(
-                        events, model=model_name,
+                        events,
+                        model=model_name,
+                        tenant_id=tenant_id,
+                        session_id=session_id,
                     )
                 if collector:
                     events = collector.observe(events)

--- a/packages/fipsagents/src/fipsagents/server/metrics.py
+++ b/packages/fipsagents/src/fipsagents/server/metrics.py
@@ -35,14 +35,37 @@ class MetricsCollector:
     """Records Prometheus metrics from StreamEvents.
 
     Requires ``prometheus_client`` (install via ``pip install 'fipsagents[metrics]'``).
+
+    ``token_label_mode`` selects which label dimensions are attached to
+    ``agent_tokens_total`` (see :class:`fipsagents.baseagent.config.MetricsConfig`).
     """
 
-    def __init__(self, *, registry: Any = None) -> None:
+    _TOKEN_LABEL_DIMENSIONS = {
+        "model": ("model", "direction"),
+        "tenant": ("model", "direction", "tenant_id"),
+        "session": ("model", "direction", "tenant_id", "session_id"),
+    }
+
+    def __init__(
+        self,
+        *,
+        registry: Any = None,
+        token_label_mode: str = "model",
+    ) -> None:
         if not _HAS_PROMETHEUS:
             raise ImportError(
                 "prometheus_client is required for MetricsCollector. "
                 "Install with: pip install 'fipsagents[metrics]'"
             )
+        if token_label_mode not in self._TOKEN_LABEL_DIMENSIONS:
+            raise ValueError(
+                f"Unknown token_label_mode {token_label_mode!r}; "
+                f"expected one of {list(self._TOKEN_LABEL_DIMENSIONS)}"
+            )
+        self._token_label_mode = token_label_mode
+        self._token_labelnames = list(
+            self._TOKEN_LABEL_DIMENSIONS[token_label_mode]
+        )
         self._registry = registry or CollectorRegistry()
 
         self.requests_total = Counter(
@@ -72,17 +95,42 @@ class MetricsCollector:
         self.tokens_total = Counter(
             "agent_tokens_total",
             "Total tokens processed",
-            labelnames=["model", "direction"],
+            labelnames=self._token_labelnames,
             registry=self._registry,
         )
+
+    def _token_labels(
+        self,
+        *,
+        model: str,
+        direction: str,
+        tenant_id: str | None,
+        session_id: str | None,
+    ) -> dict[str, str]:
+        """Build the label kwargs for ``tokens_total`` for the active mode."""
+        labels: dict[str, str] = {"model": model, "direction": direction}
+        if "tenant_id" in self._token_labelnames:
+            labels["tenant_id"] = tenant_id or "default"
+        if "session_id" in self._token_labelnames:
+            labels["session_id"] = session_id or "none"
+        return labels
 
     async def observe(
         self,
         events: AsyncIterator[StreamEvent],
         *,
         model: str,
+        tenant_id: str | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[StreamEvent]:
-        """Wrap an event stream, recording metrics as events flow through."""
+        """Wrap an event stream, recording metrics as events flow through.
+
+        ``tenant_id`` and ``session_id`` are recorded as labels on
+        ``agent_tokens_total`` only when ``token_label_mode`` includes them.
+        ``None`` falls back to ``"default"`` / ``"none"`` so the label
+        cardinality stays bounded even when the gateway omits the
+        ``X-Tenant`` header or the request has no ``session_id``.
+        """
         async for event in events:
             if isinstance(event, ToolResultEvent):
                 status = "error" if event.is_error else "ok"
@@ -94,13 +142,21 @@ class MetricsCollector:
                 m = event.metrics
                 if m.prompt_tokens is not None:
                     self.tokens_total.labels(
-                        model=model,
-                        direction="prompt",
+                        **self._token_labels(
+                            model=model,
+                            direction="prompt",
+                            tenant_id=tenant_id,
+                            session_id=session_id,
+                        ),
                     ).inc(m.prompt_tokens)
                 if m.completion_tokens is not None:
                     self.tokens_total.labels(
-                        model=model,
-                        direction="completion",
+                        **self._token_labels(
+                            model=model,
+                            direction="completion",
+                            tenant_id=tenant_id,
+                            session_id=session_id,
+                        ),
                     ).inc(m.completion_tokens)
                 if m.total_time > 0:
                     self.model_call_duration.labels(model=model).observe(
@@ -141,6 +197,8 @@ class NullMetricsCollector:
         events: AsyncIterator[StreamEvent],
         *,
         model: str,
+        tenant_id: str | None = None,
+        session_id: str | None = None,
     ) -> AsyncIterator[StreamEvent]:
         async for event in events:
             yield event
@@ -163,6 +221,8 @@ class NullMetricsCollector:
 
 def create_metrics_collector(
     enabled: bool = False,
+    *,
+    token_label_mode: str = "model",
 ) -> MetricsCollector | NullMetricsCollector:
     """Create a metrics collector based on config."""
     if not enabled:
@@ -173,4 +233,4 @@ def create_metrics_collector(
             "Install with: pip install 'fipsagents[metrics]'"
         )
         return NullMetricsCollector()
-    return MetricsCollector()
+    return MetricsCollector(token_label_mode=token_label_mode)

--- a/packages/fipsagents/tests/test_metrics.py
+++ b/packages/fipsagents/tests/test_metrics.py
@@ -120,3 +120,102 @@ class TestCreateMetricsCollector:
     def test_enabled_returns_real(self):
         c = create_metrics_collector(enabled=True)
         assert isinstance(c, MetricsCollector)
+
+    def test_token_label_mode_threaded_through(self):
+        c = create_metrics_collector(enabled=True, token_label_mode="tenant")
+        assert isinstance(c, MetricsCollector)
+        assert c._token_labelnames == ["model", "direction", "tenant_id"]
+
+
+class TestTokenLabelModes:
+    """Verify ``token_label_mode`` controls which labels land on tokens_total."""
+
+    @pytest.mark.asyncio
+    async def test_default_mode_only_model_and_direction(self):
+        c = MetricsCollector()
+        m = StreamMetrics(prompt_tokens=10, completion_tokens=5)
+        async for _ in c.observe(
+            _emit_events(StreamComplete(finish_reason="stop", metrics=m)),
+            model="m1",
+            tenant_id="acme",
+            session_id="sess1",
+        ):
+            pass
+        # tenant_id / session_id were passed but not recorded as labels.
+        val = c.tokens_total.labels(model="m1", direction="prompt")._value.get()
+        assert val == 10
+
+    @pytest.mark.asyncio
+    async def test_tenant_mode_records_tenant_id(self):
+        c = MetricsCollector(token_label_mode="tenant")
+        m = StreamMetrics(prompt_tokens=10, completion_tokens=5)
+        async for _ in c.observe(
+            _emit_events(StreamComplete(finish_reason="stop", metrics=m)),
+            model="m1",
+            tenant_id="acme",
+            session_id="sess1",
+        ):
+            pass
+        val = c.tokens_total.labels(
+            model="m1", direction="prompt", tenant_id="acme",
+        )._value.get()
+        assert val == 10
+
+    @pytest.mark.asyncio
+    async def test_tenant_mode_missing_tenant_uses_default(self):
+        c = MetricsCollector(token_label_mode="tenant")
+        m = StreamMetrics(prompt_tokens=7)
+        async for _ in c.observe(
+            _emit_events(StreamComplete(finish_reason="stop", metrics=m)),
+            model="m1",
+            tenant_id=None,
+            session_id=None,
+        ):
+            pass
+        val = c.tokens_total.labels(
+            model="m1", direction="prompt", tenant_id="default",
+        )._value.get()
+        assert val == 7
+
+    @pytest.mark.asyncio
+    async def test_session_mode_records_both(self):
+        c = MetricsCollector(token_label_mode="session")
+        m = StreamMetrics(prompt_tokens=3, completion_tokens=2)
+        async for _ in c.observe(
+            _emit_events(StreamComplete(finish_reason="stop", metrics=m)),
+            model="m1",
+            tenant_id="acme",
+            session_id="sess1",
+        ):
+            pass
+        prompt_val = c.tokens_total.labels(
+            model="m1", direction="prompt",
+            tenant_id="acme", session_id="sess1",
+        )._value.get()
+        completion_val = c.tokens_total.labels(
+            model="m1", direction="completion",
+            tenant_id="acme", session_id="sess1",
+        )._value.get()
+        assert prompt_val == 3
+        assert completion_val == 2
+
+    @pytest.mark.asyncio
+    async def test_session_mode_missing_session_uses_none(self):
+        c = MetricsCollector(token_label_mode="session")
+        m = StreamMetrics(prompt_tokens=5)
+        async for _ in c.observe(
+            _emit_events(StreamComplete(finish_reason="stop", metrics=m)),
+            model="m1",
+            tenant_id="acme",
+            session_id=None,
+        ):
+            pass
+        val = c.tokens_total.labels(
+            model="m1", direction="prompt",
+            tenant_id="acme", session_id="none",
+        )._value.get()
+        assert val == 5
+
+    def test_unknown_mode_rejected(self):
+        with pytest.raises(ValueError):
+            MetricsCollector(token_label_mode="bogus")

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -82,6 +82,7 @@ class _StubAgent(BaseAgent):
                 ),
                 metrics=types.SimpleNamespace(
                     enabled=False,
+                    token_label_mode="model",
                 ),
                 feedback=types.SimpleNamespace(
                     enabled=False,
@@ -1283,6 +1284,76 @@ def test_session_usage_computes_cumulative_dollars(tmp_path):
     # 2000/1000 * 0.01 + 1000/1000 * 0.02 = 0.02 + 0.02
     assert body["cost_usd"] == pytest.approx(0.04)
     assert body["pricing"]["input_per_1k"] == 0.01
+
+
+def test_tenant_label_flows_from_x_tenant_header(tmp_path):
+    """X-Tenant header lands on agent_tokens_total when mode is 'tenant'."""
+    pytest.importorskip("prometheus_client")
+
+    metrics = StreamMetrics(prompt_tokens=42, completion_tokens=8)
+    events = [
+        ContentDelta(content="ok"),
+        StreamComplete(finish_reason="stop", metrics=metrics),
+    ]
+    AgentClass = _make_agent_class(events, model_name="m1")
+
+    class _A(AgentClass):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.config.server.metrics = types.SimpleNamespace(
+                enabled=True, token_label_mode="tenant",
+            )
+
+    server = OpenAIChatServer(_A)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+            headers={"X-Tenant": "acme-corp"},
+        )
+        assert resp.status_code == 200
+
+        metrics_resp = client.get("/metrics")
+
+    body = metrics_resp.text
+    assert 'tenant_id="acme-corp"' in body
+    assert 'agent_tokens_total{' in body
+
+
+def test_tenant_label_defaults_when_header_absent(tmp_path):
+    """Without X-Tenant, tenant_id falls back to 'default'."""
+    pytest.importorskip("prometheus_client")
+
+    metrics = StreamMetrics(prompt_tokens=1)
+    events = [
+        ContentDelta(content="ok"),
+        StreamComplete(finish_reason="stop", metrics=metrics),
+    ]
+    AgentClass = _make_agent_class(events, model_name="m1")
+
+    class _A(AgentClass):  # type: ignore[misc, valid-type]
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.config.server.metrics = types.SimpleNamespace(
+                enabled=True, token_label_mode="tenant",
+            )
+
+    server = OpenAIChatServer(_A)
+    with TestClient(server.app) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            },
+        )
+        assert resp.status_code == 200
+        metrics_resp = client.get("/metrics")
+
+    assert 'tenant_id="default"' in metrics_resp.text
 
 
 def test_session_usage_uses_cost_data_model_over_default(tmp_path):


### PR DESCRIPTION
## Summary

PR-B of Cost Tracking v2 (refs #104). Opt-in via a new `metrics.token_label_mode` setting; default preserves the existing label space exactly so this is safe to roll out without redeploying any scrape config.

- New `MetricsConfig.token_label_mode`: `"model"` (default) | `"tenant"` | `"session"`.
- `MetricsCollector(token_label_mode=...)` varies the labelnames on `agent_tokens_total` and routes label kwargs through a shared `_token_labels()` helper.
- Server pulls `X-Tenant` off the inbound request (gateway-stamped) with a `"default"` fallback; `session_id` flows from the `ChatCompletionRequest` field. Both plumbed through `_collect_sync` / `_stream` into `MetricsCollector.observe()`.

## Cardinality

The three modes trade off label richness vs time-series count:

| Mode      | Labels                                                | Bound                       |
|-----------|-------------------------------------------------------|-----------------------------|
| `model`   | `model`, `direction`                                  | model catalog               |
| `tenant`  | `model`, `direction`, `tenant_id`                     | tenant count                |
| `session` | `model`, `direction`, `tenant_id`, `session_id`       | unbounded (one per session) |

`session` is documented as opt-in for deployments with external aggregation (federation, Mimir). For per-session views without the cardinality cost, `GET /v1/sessions/{id}/usage` (PR-A) is the preferred read path.

## YAML

```yaml
server:
  metrics:
    enabled: true
    token_label_mode: tenant  # or "model" (default), or "session"
```

## What's queued

- PR-A: PricingConfig + /usage endpoint ✅ merged (b03f194)
- **PR-B (this one):** tenant_id + session_id Prom labels
- PR-C: BudgetEnforcer observer
- PR-D: OTEL GenAI semantic conventions

## Test plan

- [x] 6 new MetricsCollector unit tests (`tests/test_metrics.py`)
- [x] 3 new TestClient integration tests verifying `X-Tenant` flows to `/metrics` (`tests/test_server_openai.py`)
- [x] Full fipsagents suite green: 784 → 793
- [ ] Cluster smoke after merge

## FIPS

No new dependencies; label routing is metadata only.