### PR TITLE
feat(server): OTEL GenAI semantic conventions on trace spans

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -243,6 +243,8 @@ Token cost tracking has two layers:
 
 When a hard limit is hit, `BudgetEnforcer` raises `BudgetExceededError`, which the server maps to **HTTP 402 Payment Required** with a structured body (`error`, `scope`, `identifier`, `current_usd`, `limit_usd`). Soft warnings emit a single `WARNING` log line per crossing per scope and then go quiet. `budget.mode: observe` downgrades hard-limit raising to log-only — useful for measuring impact before turning enforcement on.
 
+`TraceCollector` stamps OTEL GenAI semantic-convention attributes on its spans alongside the legacy attribute names: `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.system` on the request span, and `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / `gen_ai.response.model` on the model_call span. Existing trace consumers that read `prompt_tokens` / `completion_tokens` keep working; OTEL backends (Tempo, Honeycomb, Grafana Cloud) get the standard keys they expect for free.
+
 `CreateSessionRequest` is a Pydantic model that validates session IDs: alphanumeric characters, hyphens, and underscores only, 1-128 characters. The same validation applies to the optional `session_id` field on `ChatCompletionRequest`. Sessions support two creation modes: explicit creation via `POST /v1/sessions`, and auto-create-on-first-use -- when a `session_id` is passed on a chat completion request, the `save()` method uses upsert semantics and creates the session if it doesn't exist. The explicit endpoint is optional but recommended when you need to control the ID or check for duplicates.
 
 ### Traces

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -631,6 +631,7 @@ class OpenAIChatServer:
                 trace_id=trace_id,
                 session_id=req.session_id,
                 model=model_name,
+                provider=getattr(agent.config.model, "provider", None),
                 parent_span_id=parent_ctx.parent_span_id if parent_ctx else None,
             )
             collector.begin_request({

--- a/packages/fipsagents/src/fipsagents/server/collector.py
+++ b/packages/fipsagents/src/fipsagents/server/collector.py
@@ -51,6 +51,7 @@ class TraceCollector:
         parent_span_id: str | None = None,
         session_id: str | None = None,
         model: str | None = None,
+        provider: str | None = None,
     ) -> None:
         self.store = store
         # If a parent trace context is provided, use its trace ID
@@ -59,6 +60,10 @@ class TraceCollector:
         self._parent_span_id = parent_span_id
         self._session_id = session_id
         self._model = model
+        # OTEL GenAI semantic convention: gen_ai.system identifies the
+        # provider (eg "openai", "anthropic", "vllm") so trace consumers
+        # can group spans across providers without parsing model names.
+        self._provider = provider
 
         self._spans: list[Span] = []
         self._request_span: Span | None = None
@@ -97,10 +102,22 @@ class TraceCollector:
     # ------------------------------------------------------------------
 
     def begin_request(self, attributes: dict[str, Any] | None = None) -> None:
-        """Open the root request span and the first step."""
+        """Open the root request span and the first step.
+
+        Stamps OTEL GenAI semantic-convention attributes on the request
+        span (`gen_ai.operation.name`, `gen_ai.request.model`,
+        `gen_ai.system`) so trace consumers can recognise this as a
+        chat-completion regardless of how the underlying spans are named.
+        """
         self._started_at = _utc_now_iso()
+        attrs = dict(attributes or {})
+        attrs.setdefault("gen_ai.operation.name", "chat")
+        if self._model:
+            attrs.setdefault("gen_ai.request.model", self._model)
+        if self._provider:
+            attrs.setdefault("gen_ai.system", self._provider)
         self._request_span = self._make_span(
-            "request", parent_id=self._parent_span_id, **(attributes or {})
+            "request", parent_id=self._parent_span_id, **attrs,
         )
         self._begin_step()
 
@@ -132,16 +149,32 @@ class TraceCollector:
         )
 
     def _end_model_call(self, metrics: StreamMetrics | None = None) -> None:
+        """Close the model_call span, stamping token counts as attributes.
+
+        Both the legacy attribute names (``prompt_tokens`` /
+        ``completion_tokens`` / ``total_tokens``) and the OTEL GenAI
+        semantic-convention names (``gen_ai.usage.input_tokens`` /
+        ``gen_ai.usage.output_tokens``) are emitted, so existing trace
+        consumers keep working while OTEL backends (Tempo, Honeycomb,
+        Grafana Cloud) get the standard attribute keys they expect.
+        """
         if self._current_model_span is None:
             return
         if metrics is not None:
             attrs = self._current_model_span.attributes
             if metrics.prompt_tokens is not None:
                 attrs["prompt_tokens"] = metrics.prompt_tokens
+                attrs["gen_ai.usage.input_tokens"] = metrics.prompt_tokens
             if metrics.completion_tokens is not None:
                 attrs["completion_tokens"] = metrics.completion_tokens
+                attrs["gen_ai.usage.output_tokens"] = metrics.completion_tokens
             if metrics.total_tokens is not None:
                 attrs["total_tokens"] = metrics.total_tokens
+            if self._model:
+                attrs.setdefault("gen_ai.request.model", self._model)
+                attrs.setdefault("gen_ai.response.model", self._model)
+            if self._provider:
+                attrs.setdefault("gen_ai.system", self._provider)
             attrs["total_time"] = metrics.total_time
         self._end_span(self._current_model_span)
         self._current_model_span = None

--- a/packages/fipsagents/tests/test_tracing.py
+++ b/packages/fipsagents/tests/test_tracing.py
@@ -217,6 +217,64 @@ class TestTraceCollector:
         assert attrs["total_time"] == 1.2
 
     @pytest.mark.asyncio
+    async def test_otel_genai_convention_attributes(self, null_store):
+        """Token counts also surface under gen_ai.usage.* semantic-convention keys."""
+        metrics = _default_metrics(
+            prompt_tokens=150, completion_tokens=42, total_time=1.2
+        )
+        collector = TraceCollector(
+            null_store,
+            trace_id="t-genai",
+            model="gpt-oss-20b",
+            provider="vllm",
+        )
+        collector.begin_request()
+
+        events = _emit_events(
+            ContentDelta("answer"),
+            StreamComplete(finish_reason="stop", metrics=metrics),
+        )
+        [e async for e in collector.observe(events)]
+        await collector.end_request()
+
+        # Request-level: operation.name + system + request.model.
+        request_spans = [s for s in collector._spans if s.name == "request"]
+        assert len(request_spans) == 1
+        req_attrs = request_spans[0].attributes
+        assert req_attrs["gen_ai.operation.name"] == "chat"
+        assert req_attrs["gen_ai.request.model"] == "gpt-oss-20b"
+        assert req_attrs["gen_ai.system"] == "vllm"
+
+        # Model-call: usage.input_tokens + usage.output_tokens + response.model.
+        model_spans = [s for s in collector._spans if s.name == "model_call"]
+        attrs = model_spans[0].attributes
+        assert attrs["gen_ai.usage.input_tokens"] == 150
+        assert attrs["gen_ai.usage.output_tokens"] == 42
+        assert attrs["gen_ai.request.model"] == "gpt-oss-20b"
+        assert attrs["gen_ai.response.model"] == "gpt-oss-20b"
+        assert attrs["gen_ai.system"] == "vllm"
+        # Legacy attribute names preserved for backwards compatibility.
+        assert attrs["prompt_tokens"] == 150
+        assert attrs["completion_tokens"] == 42
+
+    @pytest.mark.asyncio
+    async def test_genai_attributes_omit_provider_when_none(self, null_store):
+        """Without a provider, gen_ai.system is simply not stamped (no empty string)."""
+        metrics = _default_metrics(prompt_tokens=10)
+        collector = TraceCollector(null_store, trace_id="t-noprov")
+        collector.begin_request()
+        events = _emit_events(
+            ContentDelta("ok"),
+            StreamComplete(finish_reason="stop", metrics=metrics),
+        )
+        [e async for e in collector.observe(events)]
+        await collector.end_request()
+
+        request_spans = [s for s in collector._spans if s.name == "request"]
+        assert "gen_ai.system" not in request_spans[0].attributes
+        assert request_spans[0].attributes["gen_ai.operation.name"] == "chat"
+
+    @pytest.mark.asyncio
     async def test_events_pass_through(self, null_store):
         """All original events are yielded unchanged."""
         original = [


### PR DESCRIPTION
## Summary

PR-D and final piece of Cost Tracking v2 (refs #104). Closes the OTEL GenAI conventions item in the original issue.

`TraceCollector` now stamps the OTEL GenAI semantic-convention attribute names alongside the legacy names so OTEL backends (Tempo, Honeycomb, Grafana Cloud) get the standard keys they expect for free:

- **request span:** `gen_ai.operation.name` = `"chat"`, `gen_ai.request.model`, `gen_ai.system` (when provider is known)
- **model_call span:** `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.system`

## Backwards compatibility

Legacy `prompt_tokens` / `completion_tokens` / `total_tokens` / `total_time` attributes are preserved verbatim. Anything reading the existing trace shape (TraceSummary aggregation, `GET /v1/traces/{id}` viewers, custom dashboards) keeps working unchanged.

`OTELTraceStore` needs no changes — its generic span-attribute copy loop in `otel.py` carries the new keys through to the exporter automatically.

## App-side wiring

`app.py` threads `agent.config.model.provider` into `TraceCollector` so vLLM / Anthropic / Bedrock / Azure deployments populate `gen_ai.system` correctly without touching the chat-completion code path. When provider is unset, `gen_ai.system` is simply omitted (no empty strings).

## What's queued

- PR-A: PricingConfig + /usage endpoint ✅ merged (b03f194)
- PR-B: tenant_id + session_id Prom labels ✅ merged (6864a2b)
- PR-C: BudgetEnforcer ✅ merged (07cd549)
- **PR-D (this one):** OTEL GenAI semantic conventions

After this lands, the Track B punch list from #104 is closed end-to-end.

## Test plan

- [x] 2 new tests in `tests/test_tracing.py`: full GenAI attribute coverage on both spans + a "no provider" assertion preventing empty-string regressions
- [x] Existing `test_tracing.py` + `test_otel.py` still green
- [x] Full fipsagents suite green: 808 → 810
- [ ] Cluster smoke after merge (verify Tempo / Honeycomb pick up the new keys)

## FIPS

No new dependencies; pure attribute additions.