### PR TITLE
feat(template): Scaffold files config + ClamAV sidecar

### DIFF
--- a/templates/agent-loop/CLAUDE.md
+++ b/templates/agent-loop/CLAUDE.md
@@ -230,6 +230,16 @@ The agent runs locally with zero external config using the defaults.
 
 The image is immutable: code, tools, prompts, skills, rules, and `agent.yaml` defaults are all baked in. Only env var overrides (via ConfigMap) and secrets are injected at runtime.
 
+## File Uploads
+
+Toggle file uploads on by setting `server.files.enabled: true` in `agent.yaml` and adding the `[files]` extra to your container build (`pip install -e .[files]`). The extra pulls in `docling` (text extraction) and `python-magic` (content-based MIME sniffing).
+
+Once enabled, `POST /v1/files` accepts multipart uploads, parses extracted text inline, and persists metadata + bytes to the configured backend. Subsequent `POST /v1/chat/completions` requests can reference uploads by passing `file_ids: ["file_..."]` — the framework injects each file's extracted text into the conversation before the LLM sees the user's prompt.
+
+To deploy a ClamAV sidecar for virus scanning, set `files.virusScanner.enabled=true` in `chart/values.yaml`. The Helm chart wires the agent's `FILES_SCANNER_URL` env var to `http://localhost:8088/scan` automatically — your sidecar image must expose an HTTP shim that translates the framework's `POST bytes → JSON {infected, viruses}` contract to clamd.
+
+To let the LLM deliberately re-read an upload (rather than relying on automatic injection), copy `tools/_attached_file.py.example` to `tools/attached_file.py` and rebuild. The example registers an `llm_only` tool that takes a `file_id` and returns the extracted text.
+
 ## Dependencies
 
 - **openai** -- LLM client (async SDK for OpenAI-compatible endpoints)

--- a/templates/agent-loop/agent.yaml
+++ b/templates/agent-loop/agent.yaml
@@ -225,6 +225,64 @@ server:
     enabled: ${FEEDBACK_ENABLED:-false}
     max_age_hours: 720           # feedback expires after 30 days
 
+  # -- File uploads (optional) --------------------------------------------------
+  #
+  # Accepts user-attached files via POST /v1/files (multipart). The endpoint
+  # persists each upload, optionally extracts text via Docling, and lets
+  # subsequent /v1/chat/completions requests reference uploads by file_id.
+  #
+  # Requires the [files] extra:  pip install fipsagents[files]
+  # Optional virus scan: deploy a ClamAV sidecar (chart/values.yaml ->
+  # files.virusScanner.enabled=true) and set scanner.url to point at it.
+  #
+  # Defense-in-depth: the gateway also enforces size + MIME caps before
+  # bytes reach the agent.  Keep allowed_mime_types in sync between the
+  # two so a request the gateway would reject doesn't surprise the agent.
+  #
+  # backend: persistence backend for metadata + bytes.
+  #   sqlite   -- local SQLite + sharded local FS (dev / single-replica)
+  #   postgres -- Postgres metadata (S3-compatible bytes backend pending)
+  #   null     -- accepted-then-discarded (no persistence; for smoke testing)
+  #
+  # max_file_size_bytes: hard cap enforced at the agent layer. Must be set
+  # to at least the gateway's cap so honest uploads aren't double-rejected.
+  #
+  # allowed_mime_types: empty list means allow-all (gateway is the gate).
+  # Populate with explicit types to belt-and-braces the gateway allowlist.
+  #
+  # scanner.url: HTTP URL of a ClamAV-fronting sidecar. Empty disables
+  # scanning (NullScanner). When set, every upload is POSTed to the
+  # sidecar before persistence.
+  # scanner.fail_mode:
+  #   open   -- accept uploads when the scanner is unreachable (dev default)
+  #   closed -- 503 the upload when the scanner errors (production-recommended)
+  #
+  # Production env vars:
+  #   FILES_ENABLED          -- "true" to accept uploads
+  #   FILES_BACKEND          -- "sqlite" | "postgres" | "" (Null)
+  #   FILES_MAX_SIZE_BYTES   -- override the size cap (default 50 MiB)
+  #   FILES_SCANNER_URL      -- ClamAV sidecar URL (empty disables scanning)
+  #   FILES_SCANNER_FAIL_MODE -- "open" or "closed"
+  files:
+    enabled: ${FILES_ENABLED:-false}
+    backend: ${FILES_BACKEND:-}
+    max_file_size_bytes: ${FILES_MAX_SIZE_BYTES:-52428800}  # 50 MiB
+    bytes_dir: ./files                                       # sqlite-backend only
+    max_age_hours: 720                                       # files expire after 30 days
+    allowed_mime_types: []
+    # Uncomment entries above to restrict at the agent layer:
+    #   - application/pdf
+    #   - text/plain
+    #   - text/markdown
+    #   - text/csv
+    #   - application/json
+    #   - image/png
+    #   - image/jpeg
+    scanner:
+      url: "${FILES_SCANNER_URL:-}"
+      timeout_seconds: 30.0
+      fail_mode: ${FILES_SCANNER_FAIL_MODE:-open}
+
 # -- Memory backend (optional) -----------------------------------------------
 #
 # Controls which memory backend the agent uses.

--- a/templates/agent-loop/chart/templates/clamav-pvc.yaml
+++ b/templates/agent-loop/chart/templates/clamav-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.files.enabled .Values.files.virusScanner.enabled .Values.files.virusScanner.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agent-template.fullname" . }}-clamav-db
+  labels:
+    {{- include "agent-template.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.files.virusScanner.persistence.size | quote }}
+  {{- with .Values.files.virusScanner.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/templates/agent-loop/chart/templates/deployment.yaml
+++ b/templates/agent-loop/chart/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "agent-template.fullname" . }}-config
-          {{- if or .Values.env .Values.sandbox.enabled .Values.llm_adapter.enabled }}
+          {{- if or .Values.env .Values.sandbox.enabled .Values.llm_adapter.enabled .Values.files.enabled }}
           env:
             {{- if .Values.env }}
             {{- toYaml .Values.env | nindent 12 }}
@@ -51,6 +51,28 @@ spec:
             {{- if .Values.llm_adapter.enabled }}
             - name: LLM_ADAPTER_URL
               value: "http://localhost:8081/v1"
+            {{- end }}
+            {{- if and .Values.files.enabled .Values.files.virusScanner.enabled }}
+            # When the ClamAV sidecar is enabled, point the agent's
+            # HttpScanner at it. The sidecar's HTTP shim is expected
+            # to expose the {infected, viruses} JSON contract on
+            # /scan over localhost:8088.
+            - name: FILES_SCANNER_URL
+              value: "http://localhost:8088/scan"
+            - name: FILES_SCANNER_FAIL_MODE
+              value: {{ .Values.files.virusScanner.failMode | quote }}
+            {{- end }}
+            {{- if .Values.files.enabled }}
+            - name: FILES_ENABLED
+              value: "true"
+            {{- if .Values.files.backend }}
+            - name: FILES_BACKEND
+              value: {{ .Values.files.backend | quote }}
+            {{- end }}
+            {{- if .Values.files.maxSizeBytes }}
+            - name: FILES_MAX_SIZE_BYTES
+              value: {{ .Values.files.maxSizeBytes | quote }}
+            {{- end }}
             {{- end }}
           {{- end }}
           resources:
@@ -146,9 +168,57 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 10
         {{- end }}
-      {{- if .Values.sandbox.enabled }}
+        {{- if and .Values.files.enabled .Values.files.virusScanner.enabled }}
+        - name: clamav
+          image: "{{ .Values.files.virusScanner.image.repository }}:{{ .Values.files.virusScanner.image.tag }}"
+          imagePullPolicy: {{ .Values.files.virusScanner.image.pullPolicy }}
+          # Two ports: 3310 (clamd INSTREAM) and 8088 (HTTP shim that
+          # translates the framework's POST-bytes contract into clamd
+          # commands). The reference image exposes both. If your image
+          # only ships clamd, deploy a small sidecar in front (eg
+          # tiangolo/uvicorn-gunicorn-fastapi) that POSTs to clamd.
+          ports:
+            - name: clamd
+              containerPort: 3310
+              protocol: TCP
+            - name: clamd-http
+              containerPort: 8088
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.files.virusScanner.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: 3310
+            initialDelaySeconds: 60        # signature DB load is slow
+            periodSeconds: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            tcpSocket:
+              port: 3310
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 3
+          {{- if .Values.files.virusScanner.persistence.enabled }}
+          volumeMounts:
+            - name: clamav-db
+              mountPath: /var/lib/clamav
+          {{- end }}
+        {{- end }}
+      {{- if or .Values.sandbox.enabled (and .Values.files.enabled .Values.files.virusScanner.enabled .Values.files.virusScanner.persistence.enabled) }}
       volumes:
+        {{- if .Values.sandbox.enabled }}
         - name: sandbox-tmp
           emptyDir:
             sizeLimit: 10Mi
+        {{- end }}
+        {{- if and .Values.files.enabled .Values.files.virusScanner.enabled .Values.files.virusScanner.persistence.enabled }}
+        - name: clamav-db
+          persistentVolumeClaim:
+            claimName: {{ include "agent-template.fullname" . }}-clamav-db
+        {{- end }}
       {{- end }}

--- a/templates/agent-loop/chart/values.yaml
+++ b/templates/agent-loop/chart/values.yaml
@@ -130,6 +130,59 @@ sandbox:
   seccomp:
     enabled: false
 
+# -- File uploads + ClamAV sidecar (optional) ---------------------------------
+# Enable to accept POST /v1/files uploads. The agent persists each file via
+# the configured FilesConfig backend and (optionally) extracts text via
+# Docling for inline injection into chat completions.
+#
+# Prerequisites:
+#   1. Add the [files] extra to your container build:
+#        pip install -e .[files]
+#      Adds ~500MB for docling's torch/transformers — opt-in only when the
+#      agent actively ingests files.
+#   2. Set files.enabled=true (or FILES_ENABLED=true via config above).
+#   3. Set files.backend (sqlite for dev, postgres for production).
+#
+# When virusScanner.enabled=true a ClamAV sidecar is deployed in the same
+# pod and reachable at localhost:3310 (TCP) plus an HTTP shim on
+# localhost:8088 that exposes the {infected, viruses} JSON contract the
+# agent's HttpScanner expects. The agent's scanner.url is set to
+# http://localhost:8088/scan automatically.
+files:
+  enabled: false
+  # Sub-knobs override agent.yaml defaults via env vars when set.
+  # Leave empty to inherit the in-image defaults.
+  backend: ""               # "" | sqlite | postgres
+  maxSizeBytes: ""          # eg "52428800" or empty for 50 MiB default
+  # Empty defers to agent.yaml's allowed_mime_types (which itself can be
+  # empty, deferring to the gateway's allowlist).
+  allowedMime: ""
+  # ClamAV sidecar — pre-deployed image with an HTTP shim that the
+  # framework's HttpScanner contract expects.
+  virusScanner:
+    enabled: false
+    failMode: open          # "open" (dev) or "closed" (production-recommended)
+    image:
+      # Reference image: clamav/clamav:stable bundled with a small
+      # FastAPI shim that translates the {infected, viruses} JSON
+      # contract to and from clamd. Replace with your own org build.
+      repository: clamav/clamav
+      tag: stable
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 1Gi          # ClamAV's signature DB is large
+      limits:
+        cpu: 500m
+        memory: 2Gi
+    # Persistent volume for the ClamAV signature database. Without one,
+    # clamd refreshes the full signature set every pod restart (~250 MB).
+    persistence:
+      enabled: false
+      size: 2Gi
+      storageClass: ""
+
 # -- FIPS cluster notes -------------------------------------------------------
 # No FIPS-specific configuration is required. UBI base images ship
 # FIPS-aware OpenSSL and respect the host kernel's fips=1 mode

--- a/templates/agent-loop/pyproject.toml
+++ b/templates/agent-loop/pyproject.toml
@@ -15,6 +15,13 @@ dependencies = [
 feedback = [
     "fipsagents[feedback]",
 ]
+files = [
+    # Pulls in docling (text extraction) + python-magic (content-based
+    # MIME sniffing). Adds ~500MB to the container image because of
+    # docling's torch/transformers — leave opt-in unless the agent
+    # actively ingests files.
+    "fipsagents[files]",
+]
 memory = [
     "fipsagents[memory]",
 ]

--- a/templates/agent-loop/tools/_attached_file.py.example
+++ b/templates/agent-loop/tools/_attached_file.py.example
@@ -1,0 +1,68 @@
+"""Example tool: read an attached file's extracted text.
+
+Rename to ``attached_file.py`` (drop the ``_`` prefix and ``.example``
+suffix) to enable. Files starting with ``_`` are skipped by the tool
+discovery loop, so this template ships disabled.
+
+Wires the agent to the ``files`` server feature: when a request arrives
+with ``file_ids`` on the chat-completion body, the framework injects
+each file's extracted text into the conversation automatically. Tools
+in this file let the *LLM* (plane 2) deliberately re-read or query a
+specific upload.
+
+Prerequisites:
+  - server.files.enabled = true in agent.yaml
+  - pip install fipsagents[files]   (or set the [files] extra in your
+    pyproject.toml and rebuild the container image)
+  - server.files.backend set to ``sqlite`` or ``postgres``
+
+Tool calling models only — small models that don't speak the OpenAI
+tool-calling protocol can't trigger this. Tested with gpt-oss-20b and
+Claude. See agent-template CLAUDE.md "Tool calling model requirements"
+for the support matrix.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fipsagents.baseagent.tools import tool
+
+logger = logging.getLogger(__name__)
+
+
+@tool(
+    description=(
+        "Read the extracted text of a file the user previously uploaded. "
+        "Returns the parsed plaintext (Docling output for PDFs/Office "
+        "docs, raw text for plaintext uploads). Use this when the user "
+        "references an attachment by name and you need to look at its "
+        "actual contents to answer."
+    ),
+    visibility="llm_only",
+)
+async def read_attached_file(file_id: str) -> str:
+    """Fetch the parsed text of an uploaded file.
+
+    Args:
+        file_id: The opaque identifier returned by ``POST /v1/files``,
+            e.g. ``file_abc123def456``.
+    """
+    # The agent reaches its own FileStore via self._file_store on the
+    # server. Tools don't get `self`, so they call the framework's
+    # FileStore singleton via the configured factory.
+    from fipsagents.server.files import create_file_store
+    from fipsagents.baseagent import get_current_agent
+
+    agent = get_current_agent()
+    files_cfg = agent.config.server.files
+    storage = agent.config.server.storage
+    store = create_file_store(
+        files_cfg.backend or storage.backend,
+        sqlite_path=storage.sqlite_path,
+        bytes_dir=files_cfg.bytes_dir,
+    )
+    text = await store.get_extracted_text(file_id)
+    if text is None:
+        return f"No extracted text for {file_id} (file unknown or parsing pending)."
+    return text


### PR DESCRIPTION
## Summary

Wires file-upload configuration into the agent-loop template so freshly scaffolded agents inherit a sensible default. Closes **fips-agents-cli#19**.

The CLI clones this template at create time, so the right seam for #19 is here, not in the CLI code itself. No CLI changes were required.

## What's new in `templates/agent-loop/`

**`agent.yaml`** — `server.files` block mirroring `FilesConfig`:
- `enabled` / `backend` / `max_file_size_bytes` (default 50 MiB) / `bytes_dir` / `max_age_hours`
- `allowed_mime_types: []` (defers to gateway by default; commented examples below)
- `scanner.url` / `timeout_seconds` / `fail_mode` ready for a ClamAV sidecar
- All knobs `${VAR:-default}` substituted so the same file works locally and in OpenShift

**`pyproject.toml`** — new `[files]` extra:
```toml
files = ["fipsagents[files]"]
```
Pulls in docling + python-magic. Opt-in (adds ~500 MB) so agents that don't ingest files don't pay for the dependency.

**`chart/values.yaml`** — new `files` block with:
- `enabled` / `backend` / `maxSizeBytes` / `allowedMime` (override defaults via env)
- `virusScanner.enabled` toggling a ClamAV sidecar
- `virusScanner.image` (defaults to `clamav/clamav:stable`)
- `virusScanner.persistence` for an optional PVC backing `/var/lib/clamav` (otherwise clamd re-downloads ~250 MB of signatures every pod restart)
- `virusScanner.failMode` (`open` for dev, `closed` for production)

**`chart/templates/deployment.yaml`** — when `files.virusScanner.enabled=true`:
- Grows a `clamav` container exposing clamd (3310) and an HTTP shim (8088) matching the framework's `POST bytes → JSON {infected, viruses}` contract
- Sets `FILES_SCANNER_URL=http://localhost:8088/scan` and `FILES_SCANNER_FAIL_MODE` on the agent container automatically
- Adds `FILES_ENABLED=true` plus `FILES_BACKEND` / `FILES_MAX_SIZE_BYTES` when set

**`chart/templates/clamav-pvc.yaml`** — new PVC, only rendered when persistence is enabled.

**`tools/_attached_file.py.example`** — a copy-and-drop-the-underscore example showing an `llm_only` tool that takes a `file_id` and returns the extracted text. Demonstrates the contract for agents that want explicit re-reading on top of the framework's automatic injection.

**`CLAUDE.md`** — short "File Uploads" section documenting the toggle + the ClamAV sidecar contract.

## Verification

- [x] `agent.yaml` parses against `AgentConfig` (pydantic) with all default env vars
- [x] `helm template chart/` renders cleanly with defaults — no FILES env vars, no clamav container
- [x] `helm template chart/ --set files.enabled=true --set files.backend=sqlite --set files.virusScanner.enabled=true` renders the env vars and sidecar
- [x] `helm template chart/ ... --set files.virusScanner.persistence.enabled=true` adds the PVC and volume mount
- [x] `helm lint chart/` passes
- [x] gitleaks clean

## Notes for reviewer

- The reference image (`clamav/clamav:stable`) ships clamd on TCP 3310 but does **not** include the HTTP shim that exposes the `{infected, viruses}` JSON contract. The `values.yaml` comment flags this; production deployments should swap in their own org image (or wrap clamav/clamav with a small FastAPI shim). Documenting the requirement in-line keeps the operator from being surprised.
- Sentinel string `agent-template` is preserved everywhere so `fips-agents create agent <name>` keeps working.