### PR TITLE
feat(server): PostgresFileStore

### DIFF
--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -228,6 +228,7 @@ class OpenAIChatServer:
         self._file_store = create_file_store(
             files_backend,
             sqlite_path=server_cfg.storage.sqlite_path,
+            database_url=server_cfg.storage.database_url,
             bytes_dir=server_cfg.files.bytes_dir,
             sqlite_connection=sqlite_conn,
         )

--- a/packages/fipsagents/src/fipsagents/server/files.py
+++ b/packages/fipsagents/src/fipsagents/server/files.py
@@ -573,6 +573,342 @@ CREATE TABLE IF NOT EXISTS files (
 
 
 # ---------------------------------------------------------------------------
+# Postgres backend
+# ---------------------------------------------------------------------------
+
+
+class PostgresFileStore(FileStore):
+    """Enterprise file persistence — Postgres metadata + local-FS bytes.
+
+    Mirrors :class:`PostgresSessionStore` exactly: asyncpg pool managed
+    lazily, schema created on first access, ``IF NOT EXISTS`` everywhere
+    so re-runs are safe. The bytes layout is identical to
+    :class:`SqliteFileStore` — sharded local filesystem under
+    ``bytes_dir`` — because the S3-compatible bytes backend is a
+    follow-up PR. Production deployments using Postgres should mount
+    ``bytes_dir`` on a PVC sized for the expected upload volume.
+    """
+
+    _CREATE_TABLE = """\
+CREATE TABLE IF NOT EXISTS files (
+    file_id          TEXT PRIMARY KEY,
+    session_id       TEXT,
+    user_id          TEXT NOT NULL DEFAULT 'anonymous',
+    filename         TEXT NOT NULL,
+    mime_type        TEXT NOT NULL,
+    size_bytes       BIGINT NOT NULL,
+    sha256           TEXT NOT NULL,
+    extracted_text   TEXT,
+    parse_status     TEXT NOT NULL DEFAULT 'pending',
+    parse_error      TEXT,
+    bytes_path       TEXT NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deleted_at       TIMESTAMPTZ
+)"""
+    _CREATE_INDEX_SESSION = (
+        "CREATE INDEX IF NOT EXISTS idx_files_session ON files (session_id)"
+    )
+    _CREATE_INDEX_CREATED = (
+        "CREATE INDEX IF NOT EXISTS idx_files_created ON files (created_at)"
+    )
+
+    def __init__(self, database_url: str, *, bytes_dir: str = "./files") -> None:
+        self._database_url = database_url
+        self._bytes_dir = bytes_dir
+        self._pool: Any = None  # asyncpg.Pool
+        self._initialized = False
+
+    async def _get_pool(self) -> Any:
+        if self._pool is None:
+            import asyncpg
+
+            self._pool = await asyncpg.create_pool(self._database_url)
+        if not self._initialized:
+            await self._ensure_schema()
+        return self._pool
+
+    async def _ensure_schema(self) -> None:
+        pool = self._pool
+        async with pool.acquire() as conn:
+            await conn.execute(self._CREATE_TABLE)
+            await conn.execute(self._CREATE_INDEX_SESSION)
+            await conn.execute(self._CREATE_INDEX_CREATED)
+        os.makedirs(self._bytes_dir, exist_ok=True)
+        self._initialized = True
+
+    async def save(self, record: FileRecord, data: bytes) -> str:
+        if record.size_bytes != len(data):
+            raise ValueError(
+                f"size_bytes mismatch: record says {record.size_bytes}, "
+                f"data is {len(data)} bytes"
+            )
+        actual_sha = _sha256(data)
+        if record.sha256 and record.sha256 != actual_sha:
+            raise ValueError(
+                f"sha256 mismatch for {record.file_id}: "
+                f"record says {record.sha256}, data hashes to {actual_sha}"
+            )
+        sha = record.sha256 or actual_sha
+
+        path = _bytes_path(self._bytes_dir, record.file_id)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = f"{path}.tmp"
+        with open(tmp, "wb") as fh:
+            fh.write(data)
+        os.replace(tmp, path)
+
+        # FileRecord.created_at is a string for SQLite-friendly storage;
+        # parse it back to a datetime for TIMESTAMPTZ. Default to now()
+        # when the field is empty (tests that build a record without
+        # touching the default factory).
+        created_at = _parse_iso(record.created_at) or datetime.now(timezone.utc)
+        deleted_at = _parse_iso(record.deleted_at)
+
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO files ("
+                "  file_id, session_id, user_id, filename, mime_type, "
+                "  size_bytes, sha256, extracted_text, parse_status, "
+                "  parse_error, bytes_path, created_at, deleted_at"
+                ") VALUES "
+                "($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+                record.file_id,
+                record.session_id,
+                record.user_id,
+                record.filename,
+                record.mime_type,
+                record.size_bytes,
+                sha,
+                record.extracted_text,
+                record.parse_status,
+                record.parse_error,
+                path,
+                created_at,
+                deleted_at,
+            )
+        logger.debug(
+            "PostgresFileStore: saved %s (%d bytes, sha %s..)",
+            record.file_id, record.size_bytes, sha[:8],
+        )
+        return record.file_id
+
+    async def get_metadata(self, file_id: str) -> FileRecord | None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT file_id, session_id, user_id, filename, mime_type, "
+                "       size_bytes, sha256, extracted_text, parse_status, "
+                "       parse_error, created_at, deleted_at "
+                "FROM files WHERE file_id = $1 AND deleted_at IS NULL",
+                file_id,
+            )
+        if row is None:
+            return None
+        return FileRecord(
+            file_id=row["file_id"],
+            session_id=row["session_id"],
+            user_id=row["user_id"],
+            filename=row["filename"],
+            mime_type=row["mime_type"],
+            size_bytes=row["size_bytes"],
+            sha256=row["sha256"],
+            extracted_text=row["extracted_text"],
+            parse_status=row["parse_status"],
+            parse_error=row["parse_error"],
+            created_at=_iso(row["created_at"]),
+            deleted_at=_iso(row["deleted_at"]),
+        )
+
+    async def get_bytes(self, file_id: str) -> bytes | None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT bytes_path FROM files "
+                "WHERE file_id = $1 AND deleted_at IS NULL",
+                file_id,
+            )
+        if row is None:
+            return None
+        path = row["bytes_path"]
+        try:
+            with open(path, "rb") as fh:
+                return fh.read()
+        except FileNotFoundError:
+            logger.warning(
+                "PostgresFileStore: metadata for %s exists but bytes missing at %s",
+                file_id, path,
+            )
+            return None
+
+    async def get_extracted_text(self, file_id: str) -> str | None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT extracted_text FROM files "
+                "WHERE file_id = $1 AND deleted_at IS NULL",
+                file_id,
+            )
+        if row is None:
+            return None
+        return row["extracted_text"]
+
+    async def update_extracted_text(
+        self,
+        file_id: str,
+        *,
+        extracted_text: str | None = None,
+        parse_status: ParseStatus | None = None,
+        parse_error: str | None = None,
+    ) -> bool:
+        if extracted_text is None and parse_status is None and parse_error is None:
+            return await self._exists(file_id)
+
+        # Build SET clauses with positional placeholders ($2, $3, ...).
+        sets: list[str] = []
+        params: list[Any] = []
+        if extracted_text is not None:
+            sets.append(f"extracted_text = ${len(params) + 2}")
+            params.append(extracted_text)
+        if parse_status is not None:
+            sets.append(f"parse_status = ${len(params) + 2}")
+            params.append(parse_status)
+        if parse_error is not None:
+            sets.append(f"parse_error = ${len(params) + 2}")
+            params.append(parse_error)
+
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                f"UPDATE files SET {', '.join(sets)} "
+                "WHERE file_id = $1 AND deleted_at IS NULL",
+                file_id, *params,
+            )
+        return not result.endswith("0")
+
+    async def _exists(self, file_id: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT 1 FROM files WHERE file_id = $1 AND deleted_at IS NULL",
+                file_id,
+            )
+        return row is not None
+
+    async def list_for_session(
+        self,
+        session_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[FileRecord]:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT file_id, session_id, user_id, filename, mime_type, "
+                "       size_bytes, sha256, extracted_text, parse_status, "
+                "       parse_error, created_at, deleted_at "
+                "FROM files "
+                "WHERE session_id = $1 AND deleted_at IS NULL "
+                "ORDER BY created_at DESC "
+                "LIMIT $2 OFFSET $3",
+                session_id, limit, offset,
+            )
+        return [
+            FileRecord(
+                file_id=r["file_id"],
+                session_id=r["session_id"],
+                user_id=r["user_id"],
+                filename=r["filename"],
+                mime_type=r["mime_type"],
+                size_bytes=r["size_bytes"],
+                sha256=r["sha256"],
+                extracted_text=r["extracted_text"],
+                parse_status=r["parse_status"],
+                parse_error=r["parse_error"],
+                created_at=_iso(r["created_at"]),
+                deleted_at=_iso(r["deleted_at"]),
+            )
+            for r in rows
+        ]
+
+    async def delete(self, file_id: str) -> bool:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT bytes_path FROM files "
+                "WHERE file_id = $1 AND deleted_at IS NULL",
+                file_id,
+            )
+            if row is None:
+                return False
+            path = row["bytes_path"]
+            await conn.execute(
+                "DELETE FROM files WHERE file_id = $1",
+                file_id,
+            )
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        shard_dir = os.path.dirname(path)
+        try:
+            if shard_dir and shard_dir != self._bytes_dir:
+                os.rmdir(shard_dir)
+        except OSError:
+            pass
+        return True
+
+    async def delete_before(self, cutoff: datetime) -> int:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT file_id, bytes_path FROM files WHERE created_at < $1",
+                cutoff,
+            )
+            if not rows:
+                return 0
+            for r in rows:
+                try:
+                    os.remove(r["bytes_path"])
+                except FileNotFoundError:
+                    pass
+            await conn.execute(
+                "DELETE FROM files WHERE created_at < $1",
+                cutoff,
+            )
+        deleted = len(rows)
+        if deleted:
+            logger.debug(
+                "PostgresFileStore: housekeeping removed %d files", deleted,
+            )
+        return deleted
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+            self._initialized = False
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse a FileRecord ISO timestamp string into a UTC datetime."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _iso(value: datetime | None) -> str | None:
+    """Render a Postgres TIMESTAMPTZ back to FileRecord's ISO string."""
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -581,14 +917,22 @@ def create_file_store(
     backend: str | None,
     *,
     sqlite_path: str = "./agent.db",
+    database_url: str = "",
     bytes_dir: str = "./files",
     sqlite_connection: Any = None,
 ) -> FileStore:
     """Create a file store from config values.
 
-    Only ``sqlite`` and ``None`` (Null) backends are supported in this
-    initial scaffolding. ``postgres`` and ``http`` (platform-routed) and
-    S3-compatible bytes backends land in later PRs.
+    Supported backends:
+      - ``sqlite``   — :class:`SqliteFileStore` (single-replica, dev / edge)
+      - ``postgres`` — :class:`PostgresFileStore` (metadata in PG, bytes
+                       on local FS; production deployments must mount
+                       ``bytes_dir`` on a PVC)
+      - ``http``     — platform-routed (not yet implemented)
+      - ``None``     — :class:`NullFileStore` (accepted-then-discarded)
+
+    The S3-compatible bytes backend lands in a follow-up PR; until then
+    Postgres deployments share the SQLite layout for raw bytes.
     """
     if backend == "sqlite":
         return SqliteFileStore(
@@ -596,9 +940,13 @@ def create_file_store(
             bytes_dir=bytes_dir,
             connection=sqlite_connection,
         )
-    if backend in ("postgres", "http"):
+    if backend == "postgres":
+        if not database_url:
+            raise ValueError("PostgresFileStore requires database_url")
+        return PostgresFileStore(database_url, bytes_dir=bytes_dir)
+    if backend == "http":
         raise NotImplementedError(
-            f"FileStore backend '{backend}' is not yet implemented; "
-            "use 'sqlite' or leave unset (Null)."
+            "FileStore backend 'http' is not yet implemented; "
+            "use 'sqlite', 'postgres', or leave unset (Null)."
         )
     return NullFileStore()

--- a/packages/fipsagents/tests/test_files_store.py
+++ b/packages/fipsagents/tests/test_files_store.py
@@ -453,8 +453,18 @@ class TestCreateFileStore:
         )
         assert isinstance(store, SqliteFileStore)
 
-    def test_unimplemented_backends_raise(self):
-        with pytest.raises(NotImplementedError, match="postgres"):
+    def test_postgres_requires_url(self):
+        with pytest.raises(ValueError, match="database_url"):
             create_file_store("postgres")
+
+    def test_postgres_returns_postgres_store(self):
+        from fipsagents.server.files import PostgresFileStore
+
+        store = create_file_store(
+            "postgres", database_url="postgresql://localhost/test"
+        )
+        assert isinstance(store, PostgresFileStore)
+
+    def test_http_backend_still_unimplemented(self):
         with pytest.raises(NotImplementedError, match="http"):
             create_file_store("http")


### PR DESCRIPTION
## Summary

Adds **PostgresFileStore** — Postgres-backed metadata for `/v1/files` uploads, mirroring the `PostgresSessionStore` pattern line-for-line. Closes one bullet on agent-template#100 (the "remaining backends" track from this session's NEXT_SESSION).

## What's new

**`packages/fipsagents/src/fipsagents/server/files.py`**

- New `PostgresFileStore` class implementing the full `FileStore` ABC. Lazy asyncpg pool managed the same way `PostgresSessionStore` manages it; schema created via `IF NOT EXISTS` on first access; `BIGINT` for `size_bytes`, `TIMESTAMPTZ` for `created_at` / `deleted_at`, `TEXT` for the `ParseStatus` enum (matching SqliteFileStore).
- Bytes layout is identical to `SqliteFileStore` — sharded local filesystem under `bytes_dir`. The S3-compatible bytes backend is the next bullet on agent-template#100 and lands in a follow-up; production Postgres deployments need to mount `bytes_dir` on a PVC. The class docstring flags this.
- Two small helpers (`_parse_iso`, `_iso`) bridge `FileRecord`'s ISO-string timestamps to Postgres `TIMESTAMPTZ` and back. Null-safe so records without `deleted_at` round-trip cleanly.
- `create_file_store()` now returns a `PostgresFileStore` when `backend="postgres"`, raising `ValueError` if `database_url` is absent (matches the `PostgresSessionStore` contract). `"http"` still raises `NotImplementedError` — that one waits on a corresponding `/v1/files` surface on `fipsagents-platform`.

**`packages/fipsagents/src/fipsagents/server/app.py`**

- `OpenAIChatServer.setup()` threads `storage.database_url` into the `create_file_store()` call. Previously only `sqlite_path` / `bytes_dir` / `sqlite_connection` were passed.

**`packages/fipsagents/tests/test_files_store.py`**

- Replaces `test_unimplemented_backends_raise` (which was the right shape for the original placeholder) with three targeted tests: `test_postgres_requires_url`, `test_postgres_returns_postgres_store`, and `test_http_backend_still_unimplemented`. Same pattern as `test_feedback.py::test_postgres_requires_url`.

## Test plan

- [x] `pytest -x -q` — all 1006 tests pass; 10 skipped (integration suites with no infrastructure)
- [x] `ruff check src/fipsagents/server/files.py tests/test_files_store.py src/fipsagents/server/app.py` — clean
- [x] Visual check that the schema mirrors the SQLite one (column types, NOT NULL constraints, default values)
- [ ] **Live Postgres round-trip** — out of scope for this PR. Will land alongside the S3 bytes-backend ADR or a follow-up integration test fixture.

## Notes for reviewer

- One follow-up still open on agent-template#100: the S3-compatible bytes backend. The current `PostgresFileStore` keeps bytes on local FS by design — splitting bytes from metadata is a separate ADR (option (a) in NEXT_SESSION.md). When that lands, the `bytes_dir` parameter will be replaced by a `BytesStore` ABC composed in.
- The `update_extracted_text` SQL builds positional placeholders dynamically (`$2`, `$3`, ...) the same way `PostgresFeedbackStore` does for partial updates. Audited the param numbering by hand — the `len(params) + 2` pattern keeps `$1` reserved for `file_id`.