### PR TITLE
feat(server): Chunker ABC + RecursiveTokenChunker (PR-A of #137)

### DIFF
--- a/packages/fipsagents/src/fipsagents/server/chunker.py
+++ b/packages/fipsagents/src/fipsagents/server/chunker.py
@@ -1,0 +1,365 @@
+"""Chunkers for ``/v1/files`` extracted text.
+
+Splits a long ``extracted_text`` into retrievable units before they are
+embedded and written to a :class:`ChunkStore` (added in PR-B). The
+chunker is strictly text-in / chunks-out — no embeddings, no I/O.
+
+Two-tier dispatch by parser output, mirroring :mod:`fipsagents.server.parser`:
+
+- ``RecursiveTokenChunker`` (default, no extra deps) — splits on
+  paragraph boundaries first, then sentences, then hard-cuts at the
+  token cap. Used for plaintext outputs and for Docling outputs that
+  lack hierarchy.
+- ``DoclingChunker`` (PR-D, opt-in via ``[files]`` extra) — uses
+  Docling's native ``HybridChunker`` so chunk boundaries snap to
+  headings, page breaks, and table cells.
+
+Token counting uses ``tiktoken`` when importable and falls back to a
+``len(text) // 4`` heuristic otherwise. Per ADR-0002, tiktoken is a
+soft dependency: FIPS builds prefer fewer Rust extensions and the
+heuristic is within ±20% for English-like text — good enough for
+chunk-boundary decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Token counting
+# ---------------------------------------------------------------------------
+
+
+_TIKTOKEN_ENCODING: Any | None = None
+_TIKTOKEN_PROBED: bool = False
+
+
+def _get_tiktoken_encoding() -> Any | None:
+    """Return a cached ``cl100k_base`` encoding, or ``None`` if unavailable.
+
+    Probes once and caches the result. ``cl100k_base`` is the encoding
+    used by the OpenAI ``gpt-4`` / ``gpt-3.5-turbo`` family and produces
+    counts within a few percent of most modern open-weight tokenizers
+    for English text. It is the right "generic" choice when we do not
+    know which model the deployment will route to.
+    """
+    global _TIKTOKEN_ENCODING, _TIKTOKEN_PROBED
+    if _TIKTOKEN_PROBED:
+        return _TIKTOKEN_ENCODING
+    _TIKTOKEN_PROBED = True
+    try:
+        import tiktoken
+    except ImportError:
+        logger.info(
+            "tiktoken not installed; using char/4 heuristic for chunk "
+            "token counts. Install with: pip install tiktoken"
+        )
+        _TIKTOKEN_ENCODING = None
+        return None
+    try:
+        _TIKTOKEN_ENCODING = tiktoken.get_encoding("cl100k_base")
+    except Exception as exc:  # pragma: no cover — extremely rare
+        logger.warning("tiktoken get_encoding failed: %s; using fallback", exc)
+        _TIKTOKEN_ENCODING = None
+    return _TIKTOKEN_ENCODING
+
+
+def count_tokens(text: str) -> int:
+    """Count tokens in *text*.
+
+    Uses ``tiktoken`` when available, otherwise ``len(text) // 4`` as a
+    rough English-language heuristic. The fallback systematically
+    under-counts for CJK / token-dense scripts; that is acceptable for
+    chunk-boundary decisions because it errs on the side of smaller
+    chunks (more retrieval granularity, not fewer).
+    """
+    if not text:
+        return 0
+    enc = _get_tiktoken_encoding()
+    if enc is not None:
+        return len(enc.encode(text, disallowed_special=()))
+    return max(1, len(text) // 4)
+
+
+def _reset_tiktoken_cache_for_tests() -> None:
+    """Reset the tiktoken probe cache. Test-only hook."""
+    global _TIKTOKEN_ENCODING, _TIKTOKEN_PROBED
+    _TIKTOKEN_ENCODING = None
+    _TIKTOKEN_PROBED = False
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Chunk:
+    """A single retrievable unit produced by a :class:`Chunker`.
+
+    ``content`` is what gets embedded and surfaced at retrieval time.
+    ``metadata`` is opaque to the chunker contract and is reserved for
+    parser-supplied breadcrumbs (page number, section path, table id,
+    etc.) once :class:`DoclingChunker` lands in PR-D.
+    """
+
+    content: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    token_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class Chunker(ABC):
+    """Pluggable text-to-chunks splitter."""
+
+    @abstractmethod
+    async def chunk(
+        self,
+        text: str,
+        *,
+        chunk_size_tokens: int = 600,
+        chunk_overlap_tokens: int = 100,
+    ) -> list[Chunk]:
+        """Split *text* into chunks of at most ``chunk_size_tokens``.
+
+        ``chunk_overlap_tokens`` is the target overlap between
+        consecutive chunks; implementations are free to round to the
+        nearest sensible boundary (sentence, paragraph) rather than
+        slicing mid-token.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Recursive splitter helpers
+# ---------------------------------------------------------------------------
+
+
+# Paragraph break: one or more blank lines, with optional whitespace.
+_PARAGRAPH_RE = re.compile(r"\n\s*\n+")
+
+# Sentence break: terminator (. ! ?) followed by whitespace and a
+# capital / digit / opening quote. Conservative — does not try to
+# handle abbreviations, since over-splitting is harmless (chunks just
+# get glued back by the size-bounded greedy assembler) but
+# under-splitting can produce 2 K-token "sentences" that cannot be
+# bounded.
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9\"'(\[])")
+
+
+def _split_paragraphs(text: str) -> list[str]:
+    parts = [p.strip() for p in _PARAGRAPH_RE.split(text)]
+    return [p for p in parts if p]
+
+
+def _split_sentences(text: str) -> list[str]:
+    parts = [s.strip() for s in _SENTENCE_RE.split(text)]
+    return [s for s in parts if s]
+
+
+def _hard_split_by_tokens(text: str, max_tokens: int) -> list[str]:
+    """Last-resort splitter for paragraphs/sentences that exceed the cap.
+
+    Splits on whitespace-bounded words to avoid breaking inside a token
+    when tiktoken is in use. If the result still over-shoots (extremely
+    long single word), accepts the over-shoot rather than slicing into
+    UTF-8 codepoints — chunks slightly above the cap are fine; chunks
+    that mangle text are not.
+    """
+    words = text.split()
+    if not words:
+        return []
+    out: list[str] = []
+    current: list[str] = []
+    current_tokens = 0
+    for word in words:
+        word_tokens = count_tokens(word + " ")
+        if current and current_tokens + word_tokens > max_tokens:
+            out.append(" ".join(current))
+            current = [word]
+            current_tokens = word_tokens
+        else:
+            current.append(word)
+            current_tokens += word_tokens
+    if current:
+        out.append(" ".join(current))
+    return out
+
+
+def _recursive_units(text: str, max_tokens: int) -> list[str]:
+    """Break *text* into units no larger than ``max_tokens``.
+
+    Tries paragraphs first, then sentences, then a hard word-bounded
+    split. Each unit is below the cap (or as close as possible without
+    slicing mid-word).
+    """
+    if count_tokens(text) <= max_tokens:
+        return [text]
+
+    units: list[str] = []
+    paragraphs = _split_paragraphs(text) or [text]
+    for para in paragraphs:
+        if count_tokens(para) <= max_tokens:
+            units.append(para)
+            continue
+        sentences = _split_sentences(para) or [para]
+        for sent in sentences:
+            if count_tokens(sent) <= max_tokens:
+                units.append(sent)
+            else:
+                units.extend(_hard_split_by_tokens(sent, max_tokens))
+    return units
+
+
+def _greedy_assemble(
+    units: list[str],
+    *,
+    chunk_size_tokens: int,
+    chunk_overlap_tokens: int,
+) -> list[Chunk]:
+    """Greedy-pack *units* into chunks of at most ``chunk_size_tokens``.
+
+    Adds ``chunk_overlap_tokens`` of trailing context from the previous
+    chunk to the start of each new chunk (rounded to whole units). The
+    overlap helps retrieval recall when a relevant span straddles a
+    chunk boundary.
+    """
+    if not units:
+        return []
+    if chunk_overlap_tokens >= chunk_size_tokens:
+        # Overlap larger than the chunk cap collapses to no overlap;
+        # otherwise consecutive chunks would be near-duplicates.
+        chunk_overlap_tokens = 0
+
+    chunks: list[Chunk] = []
+    current: list[str] = []
+    current_tokens = 0
+
+    for unit in units:
+        unit_tokens = count_tokens(unit)
+        if current and current_tokens + unit_tokens > chunk_size_tokens:
+            content = "\n\n".join(current)
+            chunks.append(Chunk(
+                content=content,
+                token_count=count_tokens(content),
+            ))
+            # Build overlap tail from the end of the chunk we just
+            # emitted, snapping to whole units.
+            current, current_tokens = _take_overlap(
+                current, chunk_overlap_tokens,
+            )
+        current.append(unit)
+        current_tokens += unit_tokens
+
+    if current:
+        content = "\n\n".join(current)
+        chunks.append(Chunk(
+            content=content,
+            token_count=count_tokens(content),
+        ))
+    return chunks
+
+
+def _take_overlap(units: list[str], target_tokens: int) -> tuple[list[str], int]:
+    """Return the trailing units of *units* totalling ~``target_tokens``."""
+    if target_tokens <= 0 or not units:
+        return [], 0
+    tail: list[str] = []
+    total = 0
+    for unit in reversed(units):
+        unit_tokens = count_tokens(unit)
+        if total + unit_tokens > target_tokens and tail:
+            break
+        tail.insert(0, unit)
+        total += unit_tokens
+        if total >= target_tokens:
+            break
+    return tail, total
+
+
+# ---------------------------------------------------------------------------
+# Recursive token chunker
+# ---------------------------------------------------------------------------
+
+
+class RecursiveTokenChunker(Chunker):
+    """Default chunker. Paragraph → sentence → word-bounded split.
+
+    Suitable for any plaintext input. No external dependencies (uses
+    tiktoken when present, otherwise the char/4 heuristic). Output
+    chunks are joined with double newlines so the seams remain
+    paragraph-shaped when the chunks are surfaced into a prompt.
+    """
+
+    async def chunk(
+        self,
+        text: str,
+        *,
+        chunk_size_tokens: int = 600,
+        chunk_overlap_tokens: int = 100,
+    ) -> list[Chunk]:
+        if chunk_size_tokens <= 0:
+            raise ValueError(
+                f"chunk_size_tokens must be positive, got {chunk_size_tokens}",
+            )
+        if chunk_overlap_tokens < 0:
+            raise ValueError(
+                "chunk_overlap_tokens must be non-negative, got "
+                f"{chunk_overlap_tokens}",
+            )
+        text = text.strip()
+        if not text:
+            return []
+
+        units = _recursive_units(text, chunk_size_tokens)
+        return _greedy_assemble(
+            units,
+            chunk_size_tokens=chunk_size_tokens,
+            chunk_overlap_tokens=chunk_overlap_tokens,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Null chunker
+# ---------------------------------------------------------------------------
+
+
+class NullChunker(Chunker):
+    """No-op chunker — returns an empty list. Used when chunking is disabled."""
+
+    async def chunk(
+        self,
+        text: str,
+        *,
+        chunk_size_tokens: int = 600,
+        chunk_overlap_tokens: int = 100,
+    ) -> list[Chunk]:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_chunker(*, enabled: bool = True) -> Chunker:
+    """Create the default chunker.
+
+    For now this always returns :class:`RecursiveTokenChunker` when
+    enabled. PR-D will extend the factory to auto-select
+    :class:`DoclingChunker` when the parser output looks Docling-shaped
+    and the ``[files]`` extra is installed.
+    """
+    if not enabled:
+        return NullChunker()
+    return RecursiveTokenChunker()

--- a/packages/fipsagents/tests/test_chunker.py
+++ b/packages/fipsagents/tests/test_chunker.py
@@ -1,0 +1,415 @@
+"""Tests for fipsagents.server.chunker."""
+
+from __future__ import annotations
+
+import pytest
+
+from fipsagents.server import chunker as chunker_mod
+from fipsagents.server.chunker import (
+    Chunk,
+    NullChunker,
+    RecursiveTokenChunker,
+    _greedy_assemble,
+    _hard_split_by_tokens,
+    _recursive_units,
+    _split_paragraphs,
+    _split_sentences,
+    _take_overlap,
+    count_tokens,
+    create_chunker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Token counting + tiktoken fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCountTokens:
+    def test_empty_string_returns_zero(self):
+        assert count_tokens("") == 0
+
+    def test_short_text_is_positive(self):
+        assert count_tokens("hello world") > 0
+
+    def test_longer_text_has_more_tokens(self):
+        short = count_tokens("one")
+        long = count_tokens("one two three four five six seven eight nine ten")
+        assert long > short
+
+    def test_fallback_uses_char_over_four(self, monkeypatch):
+        """When tiktoken is unavailable, count is len(text)//4 (min 1)."""
+        # Force the fallback path by stubbing the encoding probe.
+        chunker_mod._reset_tiktoken_cache_for_tests()
+        monkeypatch.setattr(chunker_mod, "_get_tiktoken_encoding", lambda: None)
+        # 40 chars / 4 = 10
+        text = "a" * 40
+        assert count_tokens(text) == 10
+        # Single char still rounds to at least 1
+        assert count_tokens("a") == 1
+
+    def test_fallback_off_by_at_most_factor_two_on_english(self, monkeypatch):
+        """Sanity-check that the heuristic is in the right order of magnitude.
+
+        We do not assert ±20% here because the exact ratio depends on
+        whether tiktoken is installed in the test environment. Instead
+        we assert both counts are positive and within a factor-of-two
+        envelope, which is the operative claim in the ADR.
+        """
+        text = (
+            "The quick brown fox jumps over the lazy dog. "
+            "Pack my box with five dozen liquor jugs. "
+            "How vexingly quick daft zebras jump."
+        )
+        chunker_mod._reset_tiktoken_cache_for_tests()
+        real = count_tokens(text)
+
+        chunker_mod._reset_tiktoken_cache_for_tests()
+        monkeypatch.setattr(chunker_mod, "_get_tiktoken_encoding", lambda: None)
+        fallback = count_tokens(text)
+
+        assert real > 0 and fallback > 0
+        ratio = max(real, fallback) / min(real, fallback)
+        assert ratio < 2.0, (
+            f"tiktoken={real} fallback={fallback} ratio={ratio:.2f}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Splitter primitives
+# ---------------------------------------------------------------------------
+
+
+class TestSplitParagraphs:
+    def test_single_paragraph(self):
+        assert _split_paragraphs("one paragraph here") == ["one paragraph here"]
+
+    def test_blank_line_separator(self):
+        assert _split_paragraphs("first\n\nsecond") == ["first", "second"]
+
+    def test_multiple_blank_lines(self):
+        assert _split_paragraphs("first\n\n\n\nsecond") == ["first", "second"]
+
+    def test_strips_whitespace(self):
+        assert _split_paragraphs("  first  \n\n  second  ") == ["first", "second"]
+
+    def test_drops_empty(self):
+        assert _split_paragraphs("\n\n\n\n") == []
+
+
+class TestSplitSentences:
+    def test_period_followed_by_capital(self):
+        out = _split_sentences("First sentence. Second sentence.")
+        assert out == ["First sentence.", "Second sentence."]
+
+    def test_question_mark(self):
+        out = _split_sentences("Are you here? I am here.")
+        assert out == ["Are you here?", "I am here."]
+
+    def test_exclamation(self):
+        out = _split_sentences("Stop! Go now.")
+        assert out == ["Stop!", "Go now."]
+
+    def test_no_split_on_lowercase_following(self):
+        # Conservative: lowercase after period (e.g. abbreviations)
+        # is *not* a split point.
+        out = _split_sentences("e.g. this is one sentence.")
+        assert out == ["e.g. this is one sentence."]
+
+    def test_handles_quoted_continuation(self):
+        out = _split_sentences('She said "hi". "Bye" was the reply.')
+        assert len(out) == 2
+
+
+class TestHardSplitByTokens:
+    def test_short_text_returns_single_unit(self):
+        assert _hard_split_by_tokens("short text", 100) == ["short text"]
+
+    def test_splits_long_text_at_word_boundary(self):
+        text = " ".join(["word"] * 200)
+        chunks = _hard_split_by_tokens(text, max_tokens=20)
+        assert len(chunks) > 1
+        # No chunk should slice mid-word
+        for c in chunks:
+            assert "word" in c
+            assert not c.startswith(" ") and not c.endswith(" ")
+
+    def test_empty_input(self):
+        assert _hard_split_by_tokens("", 100) == []
+
+    def test_single_word_over_cap_accepts_overshoot(self):
+        # Extremely long single word — we'd rather over-shoot than slice
+        # into UTF-8 codepoints.
+        word = "a" * 1000
+        out = _hard_split_by_tokens(word, max_tokens=10)
+        assert out == [word]
+
+
+class TestTakeOverlap:
+    def test_zero_target_returns_empty(self):
+        units, total = _take_overlap(["a", "b", "c"], 0)
+        assert units == []
+        assert total == 0
+
+    def test_walks_from_end(self):
+        units, total = _take_overlap(["alpha", "beta", "gamma"], 10)
+        assert units[-1] == "gamma"
+        assert total > 0
+
+    def test_empty_units(self):
+        assert _take_overlap([], 100) == ([], 0)
+
+
+# ---------------------------------------------------------------------------
+# Recursive units
+# ---------------------------------------------------------------------------
+
+
+class TestRecursiveUnits:
+    def test_short_text_under_cap_passes_through(self):
+        assert _recursive_units("hello world", 100) == ["hello world"]
+
+    def test_paragraphs_split_first(self):
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        units = _recursive_units(text, max_tokens=5)
+        # Each paragraph is short enough on its own
+        assert len(units) == 3
+
+    def test_long_paragraph_splits_to_sentences(self):
+        para = " ".join([f"Sentence number {i}." for i in range(20)])
+        units = _recursive_units(para, max_tokens=10)
+        # Sentence-level splitting kicks in
+        assert len(units) > 1
+        for u in units:
+            # Each unit is roughly one or two sentences worth
+            assert count_tokens(u) <= 30
+
+    def test_huge_sentence_falls_back_to_word_split(self):
+        sent = " ".join(["word"] * 500) + "."
+        units = _recursive_units(sent, max_tokens=20)
+        assert len(units) > 1
+
+
+# ---------------------------------------------------------------------------
+# Greedy assembler
+# ---------------------------------------------------------------------------
+
+
+class TestGreedyAssemble:
+    def test_empty_units(self):
+        assert _greedy_assemble(
+            [], chunk_size_tokens=100, chunk_overlap_tokens=10,
+        ) == []
+
+    def test_single_unit_under_cap(self):
+        chunks = _greedy_assemble(
+            ["one paragraph"],
+            chunk_size_tokens=100, chunk_overlap_tokens=10,
+        )
+        assert len(chunks) == 1
+        assert chunks[0].content == "one paragraph"
+
+    def test_packs_multiple_units(self):
+        units = [f"para {i}" for i in range(5)]
+        chunks = _greedy_assemble(
+            units, chunk_size_tokens=100, chunk_overlap_tokens=0,
+        )
+        # All packed into one chunk
+        assert len(chunks) == 1
+        for unit in units:
+            assert unit in chunks[0].content
+
+    def test_emits_multiple_chunks_when_capped(self):
+        # 50 paragraphs at ~3 tokens each = 150 tokens; cap at 30 → ~5 chunks
+        units = [f"para number {i}" for i in range(50)]
+        chunks = _greedy_assemble(
+            units, chunk_size_tokens=30, chunk_overlap_tokens=0,
+        )
+        assert len(chunks) > 1
+
+    def test_overlap_appears_in_consecutive_chunks(self):
+        units = [f"unit-{i:03d} body content here" for i in range(20)]
+        chunks = _greedy_assemble(
+            units,
+            chunk_size_tokens=30,
+            chunk_overlap_tokens=10,
+        )
+        assert len(chunks) >= 2
+        # End of chunk N should appear at the start of chunk N+1.
+        for n in range(len(chunks) - 1):
+            tail = chunks[n].content.split("\n\n")[-1]
+            assert tail in chunks[n + 1].content
+
+    def test_overlap_larger_than_cap_collapses_to_zero(self):
+        # No deduplication / loop issues when overlap >= chunk_size.
+        units = [f"unit {i}" for i in range(10)]
+        chunks = _greedy_assemble(
+            units, chunk_size_tokens=10, chunk_overlap_tokens=100,
+        )
+        assert len(chunks) >= 1
+        # Total content length is bounded; no infinite-overlap blowup.
+        total = sum(len(c.content) for c in chunks)
+        assert total < 10_000
+
+    def test_token_count_populated(self):
+        chunks = _greedy_assemble(
+            ["hello world"],
+            chunk_size_tokens=100, chunk_overlap_tokens=0,
+        )
+        assert chunks[0].token_count > 0
+
+
+# ---------------------------------------------------------------------------
+# RecursiveTokenChunker
+# ---------------------------------------------------------------------------
+
+
+class TestRecursiveTokenChunker:
+    @pytest.mark.asyncio
+    async def test_empty_text_returns_no_chunks(self):
+        chunker = RecursiveTokenChunker()
+        assert await chunker.chunk("") == []
+        assert await chunker.chunk("   \n\n  ") == []
+
+    @pytest.mark.asyncio
+    async def test_short_text_single_chunk(self):
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk("Hello world. This is a short doc.")
+        assert len(out) == 1
+        assert "Hello world" in out[0].content
+        assert out[0].token_count > 0
+
+    @pytest.mark.asyncio
+    async def test_long_doc_produces_multiple_chunks(self):
+        # Build ~3000 tokens of text via repeated paragraphs.
+        para = (
+            "The quick brown fox jumps over the lazy dog. "
+            "Pack my box with five dozen liquor jugs. "
+            "How vexingly quick daft zebras jump.\n\n"
+        )
+        text = para * 60  # ~3K-4K tokens
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk(
+            text,
+            chunk_size_tokens=400,
+            chunk_overlap_tokens=50,
+        )
+        assert len(out) >= 4
+        # No chunk much exceeds the cap (allow some slack for boundary
+        # snapping at paragraph breaks).
+        for chunk in out:
+            assert chunk.token_count < 600
+
+    @pytest.mark.asyncio
+    async def test_overlap_is_respected(self):
+        para = " ".join(f"sentence-{i}." for i in range(200))
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk(
+            para, chunk_size_tokens=80, chunk_overlap_tokens=20,
+        )
+        assert len(out) >= 2
+        # Verify each adjacent pair shares a non-trivial substring at
+        # the seam — proves overlap is happening.
+        overlap_seen = 0
+        for n in range(len(out) - 1):
+            tail_tokens = out[n].content.split()[-3:]
+            head = out[n + 1].content
+            if any(tok in head for tok in tail_tokens):
+                overlap_seen += 1
+        assert overlap_seen >= 1
+
+    @pytest.mark.asyncio
+    async def test_chunks_are_non_empty(self):
+        text = "para one.\n\npara two.\n\npara three.\n\npara four."
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk(text, chunk_size_tokens=100)
+        for chunk in out:
+            assert chunk.content.strip(), "chunk content should not be empty"
+
+    @pytest.mark.asyncio
+    async def test_invalid_chunk_size_raises(self):
+        chunker = RecursiveTokenChunker()
+        with pytest.raises(ValueError):
+            await chunker.chunk("abc", chunk_size_tokens=0)
+        with pytest.raises(ValueError):
+            await chunker.chunk("abc", chunk_size_tokens=-10)
+
+    @pytest.mark.asyncio
+    async def test_invalid_overlap_raises(self):
+        chunker = RecursiveTokenChunker()
+        with pytest.raises(ValueError):
+            await chunker.chunk("abc", chunk_overlap_tokens=-1)
+
+    @pytest.mark.asyncio
+    async def test_metadata_default_empty_dict(self):
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk("Hello world.")
+        assert out[0].metadata == {}
+
+    @pytest.mark.asyncio
+    async def test_unicode_passes_through(self):
+        text = "héllo wörld. 日本語のテキスト. مرحبا بالعالم."
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk(text)
+        assert len(out) == 1
+        assert "héllo" in out[0].content
+        assert "日本語" in out[0].content
+        assert "مرحبا" in out[0].content
+
+    @pytest.mark.asyncio
+    async def test_huge_single_paragraph_split_via_word_boundaries(self):
+        # No paragraph or sentence breaks at all — just a wall of words.
+        # Forces the hard-split fallback.
+        text = " ".join(["word"] * 2000)
+        chunker = RecursiveTokenChunker()
+        out = await chunker.chunk(
+            text,
+            chunk_size_tokens=200,
+            chunk_overlap_tokens=20,
+        )
+        assert len(out) > 1
+        for chunk in out:
+            assert "word" in chunk.content
+
+
+# ---------------------------------------------------------------------------
+# NullChunker + factory
+# ---------------------------------------------------------------------------
+
+
+class TestNullChunker:
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self):
+        chunker = NullChunker()
+        out = await chunker.chunk("anything at all goes here")
+        assert out == []
+
+
+class TestCreateChunker:
+    def test_disabled_returns_null(self):
+        assert isinstance(create_chunker(enabled=False), NullChunker)
+
+    def test_enabled_returns_recursive(self):
+        assert isinstance(create_chunker(enabled=True), RecursiveTokenChunker)
+
+    def test_default_is_enabled(self):
+        assert isinstance(create_chunker(), RecursiveTokenChunker)
+
+
+# ---------------------------------------------------------------------------
+# Chunk dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestChunk:
+    def test_default_metadata_is_empty_dict(self):
+        c = Chunk(content="hi")
+        assert c.metadata == {}
+        assert c.token_count == 0
+
+    def test_default_metadata_is_not_shared(self):
+        # Regression guard against the classic mutable-default bug.
+        a = Chunk(content="a")
+        b = Chunk(content="b")
+        a.metadata["key"] = "value"
+        assert "key" not in b.metadata


### PR DESCRIPTION
First slice of [#137](https://github.com/fips-agents/agent-template/issues/137) (ADR-0002 chunking implementation). Text-in / chunks-out only — no server wiring, no embeddings, no I/O, no new dependencies. Lands behind no callers, so main stays green.

## What's in

- `packages/fipsagents/src/fipsagents/server/chunker.py` (~270 LOC)
  - `Chunker` ABC + `Chunk` dataclass.
  - `RecursiveTokenChunker`: paragraph → sentence → word-bounded split, greedy assembly to `chunk_size_tokens`, tail-overlap of `chunk_overlap_tokens` between consecutive chunks (snapped to whole units).
  - `NullChunker` for the `chunking.enabled: false` path.
  - `count_tokens()` uses `tiktoken` (cl100k_base) when importable and falls back to `len(text) // 4` otherwise — per ADR-0002 Decisions, `tiktoken` is a soft dep so FIPS builds don't drag in the Rust extension.
  - `create_chunker(enabled=...)` factory mirroring `create_parser`.
- `packages/fipsagents/tests/test_chunker.py` (~370 LOC, 49 tests)
  - Token counting (tiktoken path + fallback path, parity envelope).
  - Splitter primitives — paragraphs, sentences (incl. quote/exclamation/abbreviation handling), hard word split.
  - Overlap helper.
  - `_recursive_units` cascade.
  - `_greedy_assemble` packing, overlap behavior, the overlap-≥-cap collapse-to-zero guard against runaway chunks.
  - `RecursiveTokenChunker` end-to-end: empty input, short doc, long doc with multiple chunks, overlap is observed, unicode passes through, invalid args raise.
  - Mutable-default-argument regression guard on `Chunk.metadata`.

Suite: **1019/1019 passing** (was 970, +49 new).

## What's not in (deliberately)

- `ChunkStore` ABC, `PgvectorChunkStore` → **PR-B**
- `FilesConfig.chunking`, `FileRecord.chunk_status`/`chunk_count`, server wiring, retrieval branch → **PR-C**
- `DoclingChunker` (opt-in via `[files]` extra) → **PR-D**
- Template `agent.yaml` env var surface, Helm chart `files.chunking` block → **PR-E**

## Test plan

- [x] All 1019 unit tests pass locally (`pytest --ignore=tests/integration`).
- [x] Ruff clean on the new files.
- [x] No regressions outside the new module.
- [ ] Reviewer sanity-check on the `_split_sentences` regex (conservative by design — over-splitting is harmless, under-splitting can produce 2K-token "sentences" that defeat the cap).

Closes part of #137. Blocks PR-B.