### PR TITLE
feat(server): ChunkStore ABC + PgvectorChunkStore (PR-B of #137)

### DIFF
--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -84,6 +84,18 @@ s3 = [
     # a transitive dep used directly for Config/exceptions.
     "aioboto3>=12.0",
 ]
+chunking = [
+    # Large-file chunking + pgvector retrieval for /v1/files (ADR-0002).
+    # Mirrors the [pgvector] extra — same asyncpg + pgvector deps because
+    # PgvectorChunkStore writes to a dedicated file_chunks table in the
+    # same database. tiktoken is intentionally NOT pinned here: per
+    # ADR-0002 §Decisions, FIPS builds prefer to skip the Rust extension,
+    # and RecursiveTokenChunker falls back to len(text)//4 when tiktoken
+    # is absent. Install with [chunking,tiktoken] for tighter token
+    # accounting.
+    "asyncpg>=0.29.0",
+    "pgvector>=0.3.0",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
@@ -109,4 +121,5 @@ markers = [
     "llamastack: Tests using LlamaStack proxy dispatch",
     "kagenti: Tests using Kagenti Gateway dispatch",
     "minio: Tests against a live MinIO/S3 endpoint (skipped when unreachable)",
+    "chunking_live: Tests against a live Postgres+pgvector and embedding endpoint (skipped when env unset)",
 ]

--- a/packages/fipsagents/src/fipsagents/server/chunk_store.py
+++ b/packages/fipsagents/src/fipsagents/server/chunk_store.py
@@ -1,0 +1,538 @@
+"""Persistent storage for file chunks (ADR-0002, PR-B).
+
+A :class:`ChunkStore` is what receives :class:`Chunk` instances from a
+:class:`fipsagents.server.chunker.Chunker`, embeds the content, and serves
+similarity-search queries at retrieval time. The store is composed beside
+the metadata :class:`FileStore` rather than replacing it — file metadata
+may live in SQLite while chunks live in Postgres+pgvector.
+
+Implementations:
+
+- :class:`NullChunkStore` — no-op default. Used when chunking is
+  disabled in :class:`FilesConfig`. Safe to call from any path.
+- :class:`PgvectorChunkStore` — production backend. asyncpg + httpx for
+  embeddings, schema mirrors :class:`PGVectorMemoryClient` but in a
+  separate ``file_chunks`` table per ADR-0002.
+
+Per the ADR, `delete_for_file` is the cascade contract — `FileStore`
+calls it during file deletion. There is *no* DB-level foreign key
+because the metadata table may live in a different database.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover — type-only imports
+    import asyncpg
+    import httpx
+
+from fipsagents.server.chunker import Chunk
+
+logger = logging.getLogger(__name__)
+
+
+_VALID_TABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DEFAULT_HTTP_TIMEOUT = 10.0
+_EMBEDDING_BATCH = 32
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _embedding_to_pgvector(embedding: list[float]) -> str:
+    """Format a float list as the pgvector literal ``[0.1,0.2,...]``."""
+    return "[" + ",".join(str(v) for v in embedding) + "]"
+
+
+async def _embed_batch(
+    http: "httpx.AsyncClient",
+    url: str,
+    model: str,
+    inputs: list[str],
+) -> list[list[float]]:
+    """Embed *inputs* via an OpenAI-compatible ``/v1/embeddings`` endpoint.
+
+    Issues one HTTP call per batch. Most embedding endpoints accept a
+    list ``input`` and return a parallel list of embeddings; we fall
+    back to one call per input if the endpoint rejects array input.
+    """
+    if not inputs:
+        return []
+    response = await http.post(
+        f"{url}/v1/embeddings",
+        json={"input": inputs, "model": model},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    data = payload.get("data") or []
+    # The "index" field is officially ordered but defensively re-sort
+    # so a misbehaving endpoint cannot scramble chunk → embedding pairing.
+    data_sorted = sorted(data, key=lambda d: d.get("index", 0))
+    return [item["embedding"] for item in data_sorted]
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class ChunkStore(ABC):
+    """Persistent store for file chunks + their embeddings."""
+
+    @abstractmethod
+    async def save_chunks(
+        self,
+        file_id: str,
+        chunks: list[Chunk],
+        *,
+        user_id: str,
+        session_id: str | None = None,
+    ) -> int:
+        """Persist *chunks* under *file_id*. Return the number written.
+
+        The implementation is responsible for embedding each chunk's
+        ``content`` and storing it alongside the row. Failures during
+        embedding are logged but should not prevent the row from being
+        written — a chunk without an embedding is still searchable via
+        text fallback in some implementations and is at minimum
+        retrievable by ``file_id`` for delete cascades.
+        """
+
+    @abstractmethod
+    async def search(
+        self,
+        file_id: str,
+        query: str,
+        *,
+        limit: int = 5,
+        min_score: float = 0.0,
+    ) -> list[Chunk]:
+        """Return the top-``limit`` chunks of *file_id* matching *query*.
+
+        Search is *per-file* by design — the user's referenced file_ids
+        are the authorization boundary, so chunks from other files
+        never leak in. ``min_score`` is a cosine-similarity floor (0
+        disables filtering).
+        """
+
+    @abstractmethod
+    async def delete_for_file(self, file_id: str) -> int:
+        """Delete every chunk for *file_id*. Return the number removed.
+
+        Called by ``FileStore.delete()`` as the app-level cascade. Must
+        be idempotent — calling it on a file that has no chunks is a
+        valid no-op.
+        """
+
+    async def close(self) -> None:
+        """Release any held resources. Default: no-op."""
+
+
+# ---------------------------------------------------------------------------
+# Null implementation
+# ---------------------------------------------------------------------------
+
+
+class NullChunkStore(ChunkStore):
+    """No-op chunk store. Used when ``files.chunking.enabled`` is false.
+
+    All operations succeed silently. This keeps the call sites in
+    :class:`OpenAIChatServer` free of ``if chunk_store is not None:``
+    guards.
+    """
+
+    async def save_chunks(
+        self,
+        file_id: str,
+        chunks: list[Chunk],
+        *,
+        user_id: str,
+        session_id: str | None = None,
+    ) -> int:
+        return 0
+
+    async def search(
+        self,
+        file_id: str,
+        query: str,
+        *,
+        limit: int = 5,
+        min_score: float = 0.0,
+    ) -> list[Chunk]:
+        return []
+
+    async def delete_for_file(self, file_id: str) -> int:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Pgvector implementation
+# ---------------------------------------------------------------------------
+
+
+def _build_schema(table: str, dimension: int) -> list[str]:
+    """Idempotent DDL for the chunks table + indexes."""
+    return [
+        "CREATE EXTENSION IF NOT EXISTS vector",
+        f"""CREATE TABLE IF NOT EXISTS {table} (
+            chunk_id    TEXT PRIMARY KEY,
+            file_id     TEXT NOT NULL,
+            user_id     TEXT NOT NULL,
+            session_id  TEXT,
+            chunk_index INT NOT NULL,
+            content     TEXT NOT NULL,
+            metadata    JSONB,
+            embedding   vector({dimension}),
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE (file_id, chunk_index)
+        )""",
+        f"CREATE INDEX IF NOT EXISTS {table}_file_id_idx ON {table} (file_id)",
+        f"""CREATE INDEX IF NOT EXISTS {table}_embedding_idx
+            ON {table} USING ivfflat (embedding vector_cosine_ops)
+            WITH (lists = 100)""",
+    ]
+
+
+class PgvectorChunkStore(ChunkStore):
+    """Postgres + pgvector chunk store with cosine-similarity retrieval.
+
+    Mirrors :class:`PGVectorMemoryClient` but writes to a separate
+    ``file_chunks`` table whose lifecycle is tied to ``FileRecord``
+    rather than to the agent's long-lived memory.
+    """
+
+    def __init__(
+        self,
+        pool: "asyncpg.Pool",
+        http: "httpx.AsyncClient",
+        embedding_url: str,
+        embedding_model: str,
+        embedding_dimension: int,
+        table_name: str = "file_chunks",
+        embedding_batch_size: int = _EMBEDDING_BATCH,
+    ) -> None:
+        if not _VALID_TABLE_NAME.match(table_name):
+            raise ValueError(
+                f"PgvectorChunkStore: invalid table_name {table_name!r}",
+            )
+        self._pool = pool
+        self._http = http
+        self._embedding_url = embedding_url
+        self._embedding_model = embedding_model
+        self._embedding_dimension = embedding_dimension
+        self._table = table_name
+        self._batch = max(1, embedding_batch_size)
+
+    # -- writes ------------------------------------------------------------
+
+    async def save_chunks(
+        self,
+        file_id: str,
+        chunks: list[Chunk],
+        *,
+        user_id: str,
+        session_id: str | None = None,
+    ) -> int:
+        if not chunks:
+            return 0
+
+        embeddings = await self._embed_chunks([c.content for c in chunks])
+        rows: list[tuple[Any, ...]] = []
+        for index, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
+            chunk_id = f"{file_id}:{index}:{uuid.uuid4().hex[:8]}"
+            metadata = json.dumps(chunk.metadata) if chunk.metadata else None
+            embedding_lit = (
+                _embedding_to_pgvector(embedding) if embedding is not None else None
+            )
+            rows.append((
+                chunk_id,
+                file_id,
+                user_id,
+                session_id,
+                index,
+                chunk.content,
+                metadata,
+                embedding_lit,
+            ))
+
+        sql = (
+            f"INSERT INTO {self._table} "  # noqa: S608
+            f"(chunk_id, file_id, user_id, session_id, chunk_index, "
+            f"content, metadata, embedding) "
+            f"VALUES ($1, $2, $3, $4, $5, $6, $7, $8::vector)"
+        )
+
+        try:
+            async with self._pool.acquire() as conn:
+                await conn.executemany(sql, rows)
+        except Exception:
+            logger.warning(
+                "PgvectorChunkStore: save_chunks failed for file_id=%s "
+                "(rows=%d) — chunks not persisted",
+                file_id,
+                len(rows),
+                exc_info=True,
+            )
+            return 0
+        return len(rows)
+
+    async def _embed_chunks(self, texts: list[str]) -> list[list[float] | None]:
+        """Embed *texts* in batches. Returns ``None`` for failed embeddings."""
+        out: list[list[float] | None] = []
+        for start in range(0, len(texts), self._batch):
+            batch = texts[start : start + self._batch]
+            try:
+                embeddings = await _embed_batch(
+                    self._http,
+                    self._embedding_url,
+                    self._embedding_model,
+                    batch,
+                )
+                if len(embeddings) != len(batch):
+                    raise ValueError(
+                        f"embedding endpoint returned {len(embeddings)} vectors "
+                        f"for {len(batch)} inputs",
+                    )
+                out.extend(embeddings)
+            except Exception:
+                logger.warning(
+                    "PgvectorChunkStore: embedding batch failed "
+                    "(start=%d, size=%d) — chunks will be stored without "
+                    "embeddings and will not be retrievable via vector search",
+                    start,
+                    len(batch),
+                    exc_info=True,
+                )
+                out.extend([None] * len(batch))
+        return out
+
+    # -- reads -------------------------------------------------------------
+
+    async def search(
+        self,
+        file_id: str,
+        query: str,
+        *,
+        limit: int = 5,
+        min_score: float = 0.0,
+    ) -> list[Chunk]:
+        try:
+            embeddings = await _embed_batch(
+                self._http,
+                self._embedding_url,
+                self._embedding_model,
+                [query],
+            )
+            if not embeddings:
+                raise RuntimeError("embedding endpoint returned no vectors")
+            query_embedding = _embedding_to_pgvector(embeddings[0])
+        except Exception:
+            logger.warning(
+                "PgvectorChunkStore: query embed failed for file_id=%s — "
+                "no chunks returned (caller should fall back to full text)",
+                file_id,
+                exc_info=True,
+            )
+            return []
+
+        # Cosine *distance* ranges 0 (identical) → 2 (opposite). We
+        # convert to a similarity score = 1 - distance so the caller's
+        # min_score is intuitive (higher = more similar).
+        sql = (
+            f"SELECT content, metadata, "  # noqa: S608
+            f"1 - (embedding <=> $1::vector) AS score "
+            f"FROM {self._table} "
+            f"WHERE file_id = $2 AND embedding IS NOT NULL "
+            f"ORDER BY embedding <=> $1::vector LIMIT $3"
+        )
+        try:
+            async with self._pool.acquire() as conn:
+                rows = await conn.fetch(sql, query_embedding, file_id, limit)
+        except Exception:
+            logger.warning(
+                "PgvectorChunkStore: search query failed for file_id=%s",
+                file_id,
+                exc_info=True,
+            )
+            return []
+
+        out: list[Chunk] = []
+        for row in rows:
+            score = float(row.get("score") or 0.0)
+            if score < min_score:
+                continue
+            metadata = row["metadata"] or {}
+            if isinstance(metadata, str):
+                # asyncpg sometimes returns JSONB as str without codec.
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError:
+                    metadata = {}
+            metadata = dict(metadata)
+            metadata["score"] = score
+            out.append(Chunk(
+                content=row["content"],
+                metadata=metadata,
+            ))
+        return out
+
+    # -- deletes -----------------------------------------------------------
+
+    async def delete_for_file(self, file_id: str) -> int:
+        try:
+            async with self._pool.acquire() as conn:
+                status = await conn.execute(
+                    f"DELETE FROM {self._table} WHERE file_id = $1",  # noqa: S608
+                    file_id,
+                )
+        except Exception:
+            logger.warning(
+                "PgvectorChunkStore: delete_for_file failed for file_id=%s",
+                file_id,
+                exc_info=True,
+            )
+            return 0
+        # asyncpg's execute returns "DELETE N" — parse the count.
+        try:
+            return int(status.split()[-1])
+        except (ValueError, IndexError, AttributeError):
+            return 0
+
+    async def close(self) -> None:
+        """Release the connection pool. Caller should not reuse the store."""
+        try:
+            await self._pool.close()
+        except Exception:  # pragma: no cover — defensive
+            logger.debug("PgvectorChunkStore: pool close raised", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Schema bootstrap
+# ---------------------------------------------------------------------------
+
+
+async def initialise_pgvector_schema(
+    pool: "asyncpg.Pool",
+    table_name: str,
+    embedding_dimension: int,
+) -> None:
+    """Apply :func:`_build_schema` to *pool* idempotently.
+
+    Logs (but does not raise) when the ivfflat index cannot be built —
+    pgvector requires at least one row in the table for ``ivfflat`` to
+    initialise on some versions; the index can be rebuilt later.
+    """
+    if not _VALID_TABLE_NAME.match(table_name):
+        raise ValueError(
+            f"initialise_pgvector_schema: invalid table_name {table_name!r}",
+        )
+    statements = _build_schema(table_name, embedding_dimension)
+    async with pool.acquire() as conn:
+        for stmt in statements:
+            try:
+                await conn.execute(stmt)
+            except Exception:
+                if "ivfflat" in stmt:
+                    logger.warning(
+                        "PgvectorChunkStore: ivfflat index could not be "
+                        "created on %s — likely the table is empty. Search "
+                        "will work without the index, just slower.",
+                        table_name,
+                    )
+                else:
+                    raise
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+async def create_pgvector_chunk_store(
+    *,
+    database_url: str,
+    embedding_url: str,
+    embedding_model: str,
+    embedding_dimension: int = 768,
+    table_name: str = "file_chunks",
+    http_timeout: float = _DEFAULT_HTTP_TIMEOUT,
+) -> ChunkStore:
+    """Create a :class:`PgvectorChunkStore` against *database_url*.
+
+    Falls back to :class:`NullChunkStore` on any initialisation error
+    so the server always gets a usable store and chat completions
+    degrade gracefully to the full-text path.
+    """
+    try:
+        import asyncpg
+        import httpx
+    except ImportError:
+        logger.error(
+            "create_pgvector_chunk_store: asyncpg/httpx not installed. "
+            "Install with: pip install fipsagents[chunking]",
+        )
+        return NullChunkStore()
+
+    if not database_url:
+        logger.error(
+            "create_pgvector_chunk_store: database_url is empty — "
+            "falling back to NullChunkStore",
+        )
+        return NullChunkStore()
+    if not embedding_url:
+        logger.error(
+            "create_pgvector_chunk_store: embedding_url is empty — "
+            "falling back to NullChunkStore",
+        )
+        return NullChunkStore()
+    if not _VALID_TABLE_NAME.match(table_name):
+        logger.error(
+            "create_pgvector_chunk_store: invalid table_name %r — "
+            "falling back to NullChunkStore",
+            table_name,
+        )
+        return NullChunkStore()
+
+    try:
+        pool = await asyncpg.create_pool(database_url)
+    except Exception:
+        logger.warning(
+            "create_pgvector_chunk_store: pool creation failed — "
+            "falling back to NullChunkStore",
+            exc_info=True,
+        )
+        return NullChunkStore()
+
+    try:
+        await initialise_pgvector_schema(pool, table_name, embedding_dimension)
+    except Exception:
+        logger.warning(
+            "create_pgvector_chunk_store: schema init failed — "
+            "falling back to NullChunkStore",
+            exc_info=True,
+        )
+        await pool.close()
+        return NullChunkStore()
+
+    http = httpx.AsyncClient(timeout=http_timeout)
+    logger.info(
+        "PgvectorChunkStore enabled (table=%s, dimension=%d)",
+        table_name,
+        embedding_dimension,
+    )
+    return PgvectorChunkStore(
+        pool=pool,
+        http=http,
+        embedding_url=embedding_url,
+        embedding_model=embedding_model,
+        embedding_dimension=embedding_dimension,
+        table_name=table_name,
+    )

--- a/packages/fipsagents/tests/test_chunk_store.py
+++ b/packages/fipsagents/tests/test_chunk_store.py
@@ -1,0 +1,666 @@
+"""Tests for fipsagents.server.chunk_store.
+
+Unit tests use mocked asyncpg + httpx — no real Postgres required.
+Live integration tests are guarded by the ``chunking_live`` marker
+and skip when ``CHUNKING_DATABASE_URL`` / ``EMBEDDING_URL`` are unset.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fipsagents.server.chunk_store import (
+    NullChunkStore,
+    _embed_batch,
+    _embedding_to_pgvector,
+    create_pgvector_chunk_store,
+)
+from fipsagents.server.chunker import Chunk
+
+try:
+    import httpx  # noqa: F401
+
+    HAS_HTTPX = True
+except ImportError:
+    HAS_HTTPX = False
+
+try:
+    import asyncpg  # noqa: F401
+
+    from fipsagents.server.chunk_store import (
+        PgvectorChunkStore,
+        initialise_pgvector_schema,
+    )
+
+    HAS_ASYNCPG = True
+except ImportError:
+    HAS_ASYNCPG = False
+
+
+pgvector_only = pytest.mark.skipif(
+    not (HAS_ASYNCPG and HAS_HTTPX),
+    reason="asyncpg/httpx not installed (install with: pip install fipsagents[chunking])",
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+def _embed_response(embeddings: list[list[float]]):
+    """Build a mock httpx response that mimics OpenAI embeddings shape."""
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(return_value={
+        "data": [
+            {"index": i, "embedding": emb} for i, emb in enumerate(embeddings)
+        ],
+    })
+    return response
+
+
+def _mock_pool(
+    fetch_return: list | None = None,
+    execute_return: str = "DELETE 0",
+    executemany_return: str = "INSERT 0 0",
+):
+    """Build a MagicMock asyncpg pool with async-context acquire support."""
+    mock_conn = AsyncMock()
+    mock_conn.execute = AsyncMock(return_value=execute_return)
+    mock_conn.executemany = AsyncMock(return_value=executemany_return)
+    mock_conn.fetch = AsyncMock(return_value=fetch_return or [])
+
+    pool = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=mock_conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+    pool.close = AsyncMock()
+    return pool, mock_conn
+
+
+def _mock_http(embeddings: list[list[float]] | Exception):
+    """Build a mock httpx.AsyncClient that returns *embeddings* on /v1/embeddings."""
+    http = MagicMock()
+    if isinstance(embeddings, Exception):
+        http.post = AsyncMock(side_effect=embeddings)
+    else:
+        http.post = AsyncMock(return_value=_embed_response(embeddings))
+    return http
+
+
+def _make_store(
+    *,
+    pool=None,
+    http=None,
+    dimension: int = 4,
+    table: str = "file_chunks",
+    batch: int = 32,
+):
+    if not HAS_ASYNCPG:
+        pytest.skip("asyncpg not installed")
+    if pool is None:
+        pool, _ = _mock_pool()
+    if http is None:
+        http = _mock_http([[0.1] * dimension])
+    return PgvectorChunkStore(
+        pool=pool,
+        http=http,
+        embedding_url="http://embed:8000",
+        embedding_model="all-MiniLM-L6-v2",
+        embedding_dimension=dimension,
+        table_name=table,
+        embedding_batch_size=batch,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (always run — no dep on asyncpg)
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingFormat:
+    def test_simple(self):
+        assert _embedding_to_pgvector([0.1, 0.2, 0.3]) == "[0.1,0.2,0.3]"
+
+    def test_empty(self):
+        assert _embedding_to_pgvector([]) == "[]"
+
+    def test_negative_values(self):
+        assert _embedding_to_pgvector([-0.5, 0.0, 1.0]) == "[-0.5,0.0,1.0]"
+
+
+class TestEmbedBatch:
+    @pytest.mark.asyncio
+    async def test_empty_input_returns_empty(self):
+        # Should not even hit the network when no inputs are given.
+        http = MagicMock()
+        http.post = AsyncMock()
+        out = await _embed_batch(http, "http://embed:8000", "model", [])
+        assert out == []
+        http.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_embeddings_in_input_order(self):
+        # Endpoint returns data with shuffled "index" — function should
+        # sort by index so chunk-N pairs with embedding-N.
+        http = MagicMock()
+        http.post = AsyncMock(return_value=MagicMock(
+            raise_for_status=MagicMock(),
+            json=MagicMock(return_value={
+                "data": [
+                    {"index": 1, "embedding": [0.2, 0.2]},
+                    {"index": 0, "embedding": [0.1, 0.1]},
+                    {"index": 2, "embedding": [0.3, 0.3]},
+                ],
+            }),
+        ))
+        out = await _embed_batch(http, "http://e:8000", "m", ["a", "b", "c"])
+        assert out == [[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]]
+
+    @pytest.mark.asyncio
+    async def test_propagates_http_errors(self):
+        http = _mock_http(RuntimeError("upstream 503"))
+        with pytest.raises(RuntimeError, match="503"):
+            await _embed_batch(http, "http://e:8000", "m", ["x"])
+
+
+# ---------------------------------------------------------------------------
+# NullChunkStore
+# ---------------------------------------------------------------------------
+
+
+class TestNullChunkStore:
+    @pytest.mark.asyncio
+    async def test_save_returns_zero(self):
+        store = NullChunkStore()
+        chunks = [Chunk(content="anything")]
+        n = await store.save_chunks(
+            "file-1", chunks, user_id="u1", session_id="s1",
+        )
+        assert n == 0
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty(self):
+        store = NullChunkStore()
+        out = await store.search("file-1", "any query")
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_zero(self):
+        store = NullChunkStore()
+        assert await store.delete_for_file("file-1") == 0
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop(self):
+        store = NullChunkStore()
+        await store.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# PgvectorChunkStore — construction + validation
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestConstruction:
+    def test_invalid_table_name_rejected(self):
+        with pytest.raises(ValueError, match="invalid table_name"):
+            _make_store(table="bad table; DROP TABLE users")
+
+    def test_table_name_with_special_chars_rejected(self):
+        with pytest.raises(ValueError):
+            _make_store(table="file_chunks'")
+
+    def test_valid_table_names_accepted(self):
+        for name in ("file_chunks", "_chunks", "agentX", "T_1_2"):
+            store = _make_store(table=name)
+            assert store._table == name
+
+    def test_batch_size_minimum_one(self):
+        store = _make_store(batch=0)
+        assert store._batch == 1
+
+
+# ---------------------------------------------------------------------------
+# save_chunks
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestSaveChunks:
+    @pytest.mark.asyncio
+    async def test_empty_chunks_skips_db(self):
+        pool, conn = _mock_pool()
+        http = _mock_http([])
+        store = _make_store(pool=pool, http=http)
+        n = await store.save_chunks(
+            "file-1", [], user_id="u1", session_id="s1",
+        )
+        assert n == 0
+        conn.executemany.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_writes_one_row_per_chunk(self):
+        pool, conn = _mock_pool()
+        http = _mock_http([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        chunks = [
+            Chunk(content="alpha", metadata={"page": 1}),
+            Chunk(content="beta"),
+        ]
+        n = await store.save_chunks(
+            "file-1", chunks, user_id="u1", session_id="s1",
+        )
+        assert n == 2
+        conn.executemany.assert_awaited_once()
+        sql, rows = conn.executemany.await_args.args
+        assert "INSERT INTO file_chunks" in sql
+        assert len(rows) == 2
+        # chunk_index must be 0, 1 (positional column 5 in the row tuple)
+        assert rows[0][4] == 0
+        assert rows[1][4] == 1
+        # content column 6
+        assert rows[0][5] == "alpha"
+        assert rows[1][5] == "beta"
+        # metadata column 7 → JSON string for chunk-0, None for chunk-1
+        assert rows[0][6] == json.dumps({"page": 1})
+        assert rows[1][6] is None
+        # embedding column 8 → pgvector literal
+        assert rows[0][7] == "[0.1,0.2,0.3,0.4]"
+
+    @pytest.mark.asyncio
+    async def test_chunk_ids_are_unique_per_file(self):
+        pool, conn = _mock_pool()
+        http = _mock_http([[0.0] * 4 for _ in range(3)])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        await store.save_chunks(
+            "file-1",
+            [Chunk(content=f"c{i}") for i in range(3)],
+            user_id="u1",
+        )
+        rows = conn.executemany.await_args.args[1]
+        chunk_ids = {row[0] for row in rows}
+        assert len(chunk_ids) == 3
+        for cid in chunk_ids:
+            assert cid.startswith("file-1:")
+
+    @pytest.mark.asyncio
+    async def test_embedding_failure_stores_null_embedding(self):
+        # Embedding service is down; chunks should still be persisted
+        # (without embeddings, so they will not be retrievable via vector
+        # search but still cleanable via delete_for_file).
+        pool, conn = _mock_pool()
+        http = _mock_http(RuntimeError("embed down"))
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        n = await store.save_chunks(
+            "file-1",
+            [Chunk(content="x"), Chunk(content="y")],
+            user_id="u1",
+        )
+        assert n == 2
+        rows = conn.executemany.await_args.args[1]
+        # Embedding column is None for every row
+        for row in rows:
+            assert row[7] is None
+
+    @pytest.mark.asyncio
+    async def test_db_failure_returns_zero(self):
+        pool, conn = _mock_pool()
+        conn.executemany = AsyncMock(side_effect=RuntimeError("connection lost"))
+        http = _mock_http([[0.0] * 4])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        n = await store.save_chunks(
+            "file-1", [Chunk(content="x")], user_id="u1",
+        )
+        assert n == 0
+
+    @pytest.mark.asyncio
+    async def test_batches_embedding_calls(self):
+        # 70 chunks at batch_size=32 → 3 calls (32 + 32 + 6).
+        pool, conn = _mock_pool()
+        embeddings_per_call = [
+            [[0.0] * 4 for _ in range(32)],
+            [[0.0] * 4 for _ in range(32)],
+            [[0.0] * 4 for _ in range(6)],
+        ]
+        http = MagicMock()
+        http.post = AsyncMock(side_effect=[
+            _embed_response(emb) for emb in embeddings_per_call
+        ])
+        store = _make_store(pool=pool, http=http, dimension=4, batch=32)
+
+        chunks = [Chunk(content=f"c{i}") for i in range(70)]
+        n = await store.save_chunks("file-1", chunks, user_id="u1")
+        assert n == 70
+        assert http.post.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# search
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_returns_chunks_with_scores(self):
+        rows = [
+            {"content": "first chunk", "metadata": {"page": 1}, "score": 0.92},
+            {"content": "second chunk", "metadata": None, "score": 0.81},
+        ]
+        pool, conn = _mock_pool(fetch_return=rows)
+        http = _mock_http([[0.1, 0.2, 0.3, 0.4]])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        out = await store.search("file-1", "what about page 1?")
+        assert len(out) == 2
+        assert out[0].content == "first chunk"
+        assert out[0].metadata["score"] == pytest.approx(0.92)
+        assert out[0].metadata["page"] == 1
+        # Chunk with no DB metadata still gets a score key.
+        assert out[1].metadata == {"score": pytest.approx(0.81)}
+
+    @pytest.mark.asyncio
+    async def test_filters_by_min_score(self):
+        rows = [
+            {"content": "high",  "metadata": None, "score": 0.95},
+            {"content": "med",   "metadata": None, "score": 0.55},
+            {"content": "low",   "metadata": None, "score": 0.20},
+        ]
+        pool, conn = _mock_pool(fetch_return=rows)
+        http = _mock_http([[0.0, 0.0, 0.0, 1.0]])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        out = await store.search("file-1", "q", limit=10, min_score=0.5)
+        assert [c.content for c in out] == ["high", "med"]
+
+    @pytest.mark.asyncio
+    async def test_limit_passed_to_query(self):
+        pool, conn = _mock_pool(fetch_return=[])
+        http = _mock_http([[0.0, 0.0, 0.0, 1.0]])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        await store.search("file-1", "q", limit=7)
+        # The third positional arg of fetch is the limit.
+        args = conn.fetch.await_args.args
+        assert args[-1] == 7
+        # The second positional arg is file_id (per-file scoping).
+        assert args[-2] == "file-1"
+
+    @pytest.mark.asyncio
+    async def test_query_embed_failure_returns_empty(self):
+        pool, conn = _mock_pool()
+        http = _mock_http(RuntimeError("embed down"))
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        out = await store.search("file-1", "q")
+        assert out == []
+        # Did not even reach the SQL fetch.
+        conn.fetch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_db_failure_returns_empty(self):
+        pool, conn = _mock_pool()
+        conn.fetch = AsyncMock(side_effect=RuntimeError("connection lost"))
+        http = _mock_http([[0.0, 0.0, 0.0, 1.0]])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        out = await store.search("file-1", "q")
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_metadata_decoded_from_json_string(self):
+        # Some asyncpg configurations return JSONB as a str — the store
+        # should decode it back to a dict.
+        rows = [{
+            "content": "c",
+            "metadata": json.dumps({"page": 42, "section": "intro"}),
+            "score": 0.7,
+        }]
+        pool, conn = _mock_pool(fetch_return=rows)
+        http = _mock_http([[0.0, 0.0, 0.0, 1.0]])
+        store = _make_store(pool=pool, http=http, dimension=4)
+
+        out = await store.search("file-1", "q")
+        assert out[0].metadata["page"] == 42
+        assert out[0].metadata["section"] == "intro"
+
+
+# ---------------------------------------------------------------------------
+# delete_for_file
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestDeleteForFile:
+    @pytest.mark.asyncio
+    async def test_returns_count_from_status(self):
+        pool, conn = _mock_pool(execute_return="DELETE 5")
+        store = _make_store(pool=pool)
+        n = await store.delete_for_file("file-1")
+        assert n == 5
+
+    @pytest.mark.asyncio
+    async def test_zero_when_no_rows_match(self):
+        pool, conn = _mock_pool(execute_return="DELETE 0")
+        store = _make_store(pool=pool)
+        assert await store.delete_for_file("file-not-there") == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_db_error(self):
+        pool, conn = _mock_pool()
+        conn.execute = AsyncMock(side_effect=RuntimeError("conn lost"))
+        store = _make_store(pool=pool)
+        assert await store.delete_for_file("file-1") == 0
+
+    @pytest.mark.asyncio
+    async def test_unparseable_status_returns_zero(self):
+        pool, conn = _mock_pool(execute_return="OK")
+        store = _make_store(pool=pool)
+        assert await store.delete_for_file("file-1") == 0
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestClose:
+    @pytest.mark.asyncio
+    async def test_close_calls_pool_close(self):
+        pool, _ = _mock_pool()
+        store = _make_store(pool=pool)
+        await store.close()
+        pool.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# initialise_pgvector_schema
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestInitialiseSchema:
+    @pytest.mark.asyncio
+    async def test_runs_all_statements(self):
+        pool, conn = _mock_pool()
+        await initialise_pgvector_schema(pool, "file_chunks", 768)
+        # 4 statements: extension, table, file_id index, embedding index.
+        assert conn.execute.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_swallows_ivfflat_failure(self):
+        pool, conn = _mock_pool()
+        # Make only the ivfflat statement fail.
+        async def execute_side_effect(stmt, *args, **kwargs):
+            if "ivfflat" in stmt:
+                raise RuntimeError("table empty")
+            return "OK"
+        conn.execute = AsyncMock(side_effect=execute_side_effect)
+        # Should not raise.
+        await initialise_pgvector_schema(pool, "file_chunks", 768)
+
+    @pytest.mark.asyncio
+    async def test_propagates_non_ivfflat_failure(self):
+        pool, conn = _mock_pool()
+        async def execute_side_effect(stmt, *args, **kwargs):
+            if "CREATE TABLE" in stmt:
+                raise RuntimeError("permission denied")
+            return "OK"
+        conn.execute = AsyncMock(side_effect=execute_side_effect)
+        with pytest.raises(RuntimeError, match="permission denied"):
+            await initialise_pgvector_schema(pool, "file_chunks", 768)
+
+    @pytest.mark.asyncio
+    async def test_invalid_table_name_rejected(self):
+        pool, _ = _mock_pool()
+        with pytest.raises(ValueError, match="invalid table_name"):
+            await initialise_pgvector_schema(pool, "bad name", 768)
+
+
+# ---------------------------------------------------------------------------
+# create_pgvector_chunk_store factory
+# ---------------------------------------------------------------------------
+
+
+@pgvector_only
+class TestCreatePgvectorChunkStore:
+    @pytest.mark.asyncio
+    async def test_falls_back_when_database_url_empty(self):
+        store = await create_pgvector_chunk_store(
+            database_url="",
+            embedding_url="http://e:8000",
+            embedding_model="m",
+        )
+        assert isinstance(store, NullChunkStore)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_embedding_url_empty(self):
+        store = await create_pgvector_chunk_store(
+            database_url="postgresql://localhost/x",
+            embedding_url="",
+            embedding_model="m",
+        )
+        assert isinstance(store, NullChunkStore)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_invalid_table_name(self):
+        store = await create_pgvector_chunk_store(
+            database_url="postgresql://localhost/x",
+            embedding_url="http://e:8000",
+            embedding_model="m",
+            table_name="bad name",
+        )
+        assert isinstance(store, NullChunkStore)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_pool_fails(self):
+        with patch(
+            "asyncpg.create_pool",
+            new=AsyncMock(side_effect=RuntimeError("connection refused")),
+        ):
+            store = await create_pgvector_chunk_store(
+                database_url="postgresql://localhost/x",
+                embedding_url="http://e:8000",
+                embedding_model="m",
+            )
+        assert isinstance(store, NullChunkStore)
+
+    @pytest.mark.asyncio
+    async def test_returns_pgvector_store_on_success(self):
+        pool, conn = _mock_pool()
+        with patch(
+            "asyncpg.create_pool",
+            new=AsyncMock(return_value=pool),
+        ):
+            store = await create_pgvector_chunk_store(
+                database_url="postgresql://localhost/x",
+                embedding_url="http://e:8000",
+                embedding_model="m",
+                table_name="file_chunks",
+                embedding_dimension=4,
+            )
+        assert isinstance(store, PgvectorChunkStore)
+        # Schema bootstrap ran (4 DDL statements).
+        assert conn.execute.await_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Live integration tests (marked, env-gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.chunking_live
+@pgvector_only
+class TestLivePgvector:
+    """Live tests against a real Postgres+pgvector and embedding endpoint.
+
+    Skipped unless ``CHUNKING_DATABASE_URL`` and ``EMBEDDING_URL`` are
+    set. Run manually with::
+
+        CHUNKING_DATABASE_URL=postgresql://... \\
+        EMBEDDING_URL=http://... \\
+        EMBEDDING_MODEL=all-MiniLM-L6-v2 \\
+        EMBEDDING_DIMENSION=384 \\
+        pytest -m chunking_live
+    """
+
+    @pytest.fixture
+    def live_config(self):
+        db = os.environ.get("CHUNKING_DATABASE_URL")
+        embed = os.environ.get("EMBEDDING_URL")
+        if not (db and embed):
+            pytest.skip(
+                "live test requires CHUNKING_DATABASE_URL and EMBEDDING_URL",
+            )
+        return {
+            "database_url": db,
+            "embedding_url": embed,
+            "embedding_model": os.environ.get(
+                "EMBEDDING_MODEL", "all-MiniLM-L6-v2",
+            ),
+            "embedding_dimension": int(
+                os.environ.get("EMBEDDING_DIMENSION", "384"),
+            ),
+            "table_name": os.environ.get(
+                "CHUNKING_TABLE", "file_chunks_test",
+            ),
+        }
+
+    @pytest.mark.asyncio
+    async def test_round_trip(self, live_config):
+        store = await create_pgvector_chunk_store(**live_config)
+        assert isinstance(store, PgvectorChunkStore)
+        try:
+            file_id = f"test-{os.getpid()}"
+            await store.delete_for_file(file_id)  # clean slate
+
+            chunks = [
+                Chunk(content="The quick brown fox jumps over the lazy dog."),
+                Chunk(content="Pack my box with five dozen liquor jugs."),
+                Chunk(content="How vexingly quick daft zebras jump."),
+            ]
+            n = await store.save_chunks(
+                file_id, chunks, user_id="test-user",
+            )
+            assert n == 3
+
+            results = await store.search(file_id, "fox jumps", limit=2)
+            assert len(results) >= 1
+            # The fox sentence should rank first or near first.
+            assert any("fox" in r.content for r in results)
+
+            removed = await store.delete_for_file(file_id)
+            assert removed == 3
+        finally:
+            await store.close()


### PR DESCRIPTION
Second slice of [#137](https://github.com/fips-agents/agent-template/issues/137) (ADR-0002). Adds the persistent storage layer for file chunks. Lands behind no callers — `OpenAIChatServer` wiring follows in PR-C.

## What's in

- `packages/fipsagents/src/fipsagents/server/chunk_store.py` (~540 LOC)
  - `ChunkStore` ABC with `save_chunks` / `search` / `delete_for_file` / `close`.
  - `NullChunkStore` — no-op default for `chunking.enabled: false`.
  - `PgvectorChunkStore` — asyncpg + httpx, mirrors the schema/usage of `PGVectorMemoryClient` but in a separate `file_chunks` table per the ADR. Idempotent DDL with ivfflat cosine index. Embedding calls batched (default size 32). Per-file scoping at retrieval (the user's referenced `file_ids` are the auth boundary). Cosine *distance* converted to similarity score (`1 - distance`) so `min_score` is intuitive.
  - `initialise_pgvector_schema` bootstrap helper (swallows ivfflat-on-empty-table failure with a warning, like `PGVectorMemoryClient`).
  - `create_pgvector_chunk_store` factory — falls back to `NullChunkStore` on any init error so chat completions degrade to full-text rather than 5xx.
- `packages/fipsagents/tests/test_chunk_store.py` (~480 LOC, 41 tests)
  - 40 unit tests with mocked asyncpg + httpx covering: embed-batch ordering and error propagation; null-store no-op semantics; constructor table-name validation; `save_chunks` write shape, embedding-failure-stores-null-embedding, batching across embedding-call sizes; `search` score filtering, limit propagation, JSONB-as-string decoding, embed-failure short-circuit; `delete_for_file` parsing; schema bootstrap including the ivfflat-failure swallow; factory fallback paths.
  - 1 live integration test (`chunking_live` marker) that skips unless `CHUNKING_DATABASE_URL` and `EMBEDDING_URL` are set. Runs round-trip save → search → delete against real pgvector.
- `packages/fipsagents/pyproject.toml`
  - `[chunking]` extra: `asyncpg>=0.29.0`, `pgvector>=0.3.0`. **No `tiktoken`** — per ADR-0002 §Decisions, FIPS builds prefer to skip the Rust extension and `RecursiveTokenChunker` falls back to `len(text)//4` when absent. Deployments that want tighter token accounting install `[chunking,tiktoken]`.
  - New `chunking_live` pytest marker.

## What's not in (deliberately)

- `FilesConfig.chunking`, `FileRecord.chunk_status`/`chunk_count`, server wiring, retrieval branch in `_resolve_file_attachments` → **PR-C** (this PR is the foundation).
- `DoclingChunker` (Docling-aware splitter) → **PR-D**.
- Template `agent.yaml` env var surface, Helm chart `files.chunking` block → **PR-E**.

## Test plan

- [x] All 1059 unit tests pass locally (`pytest --ignore=tests/integration`); +40 new from PR-B.
- [x] Ruff clean on the new files.
- [x] No regressions outside the new module.
- [ ] Reviewer to verify the "embedding-failure stores NULL embedding" path is the right choice vs. "skip the row" — current behaviour is "row written without embedding so the delete cascade still cleans it up; row will not surface in vector search until re-embedded". Documented in the docstring.
- [ ] Live `chunking_live` test will be exercised in PR-C's cluster smoke. Manual run available via env vars (see test docstring).

## Notes for reviewers

- **`embed_batch` re-sorts by `index`** — defensively, against an embedding endpoint that scrambles its `data` array. Mismatched chunk → embedding pairing would be a silent correctness bug, so the cost of one extra sort is worth paying.
- **Distance → similarity inversion** in `search` (`1 - (embedding <=> q)`) makes `min_score=0.5` mean "at least 50% similar", not "distance ≤ 0.5". Easier to reason about and matches the convention most reranker APIs use.
- **No DB-level FK** between `file_chunks.file_id` and the metadata table — the metadata may live in SQLite; cascade is enforced in app code via `delete_for_file`. Documented in the module docstring and in the ADR.

Closes part of #137. Blocks PR-C.