### PR TITLE
feat(server): heading-aware DoclingChunker + auto-selection (PR-D of #137)

### DIFF
--- a/packages/fipsagents/src/fipsagents/server/chunker.py
+++ b/packages/fipsagents/src/fipsagents/server/chunker.py
@@ -348,18 +348,204 @@ class NullChunker(Chunker):
 
 
 # ---------------------------------------------------------------------------
+# Markdown-aware Docling chunker
+# ---------------------------------------------------------------------------
+
+
+# ATX-style markdown headings: 1-6 leading hashes, a space, then the
+# heading text. Setext headings (=== / ---) are not handled — Docling's
+# markdown export uses ATX exclusively.
+_HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<title>.+?)\s*$", re.MULTILINE)
+
+
+def _split_by_headings(
+    text: str,
+) -> list[tuple[list[str], str]]:
+    """Split *text* into (heading_path, body) sections.
+
+    ``heading_path`` is a breadcrumb of titles from the document root to
+    the section's heading (most recent ATX heading at each level). The
+    body is everything between this heading and the next at the same or
+    higher level. The *first* section may have an empty heading_path
+    when the document begins with prose before any heading.
+
+    Markdown produced by Docling's ``export_to_markdown`` typically
+    uses level-1 for the document title, level-2 for major sections,
+    level-3+ for subsections, and inline ``###`` markers for
+    table-of-contents-style structure. The chunker uses these as
+    *primary* split boundaries — a single heading boundary is a
+    stronger semantic cut than a paragraph break.
+    """
+    matches = list(_HEADING_RE.finditer(text))
+    if not matches:
+        return [([], text)]
+
+    sections: list[tuple[list[str], str]] = []
+    cursor: list[str] = []  # current heading-path stack
+
+    # Prologue: text before the first heading.
+    first_start = matches[0].start()
+    if first_start > 0:
+        prologue = text[:first_start].strip()
+        if prologue:
+            sections.append(([], prologue))
+
+    for i, match in enumerate(matches):
+        level = len(match.group("hashes"))
+        title = match.group("title").strip()
+        # Pop until the path is shallower than the current heading,
+        # then push the new title.
+        while len(cursor) >= level:
+            cursor.pop()
+        # Pad with empty strings if the doc skips heading levels (h1 → h3).
+        while len(cursor) < level - 1:
+            cursor.append("")
+        cursor.append(title)
+
+        body_start = match.end()
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[body_start:body_end].strip()
+        # Always emit, even if body is empty — preserves heading-path
+        # context for empty sections (caller can drop them later).
+        sections.append((list(cursor), body))
+
+    return sections
+
+
+def _heading_path_text(path: list[str]) -> str:
+    """Render a heading path as ``H1 > H2 > H3``."""
+    return " > ".join(p for p in path if p)
+
+
+class DoclingChunker(Chunker):
+    """Chunker that respects markdown headings produced by Docling.
+
+    Splits the input on ATX heading boundaries first, captures the
+    heading path in :attr:`Chunk.metadata.section_path`, then falls
+    back to :class:`RecursiveTokenChunker`'s paragraph-→-sentence-→-
+    word recursion *within* each section. The result is chunks that
+    line up with the document's structural skeleton, which usually
+    yields much better retrieval recall than chunking purely on
+    paragraph breaks.
+
+    Despite the name, this chunker does not require Docling at runtime
+    — it works on any heading-rich markdown. Its purpose is to be the
+    smarter default when the upstream parser was Docling, since
+    Docling's output is reliably heading-rich. The ``[files]`` extra
+    is the de-facto availability signal: when Docling is installed,
+    most binary uploads land here; when it is not, the parser produces
+    plaintext and there is no heading structure to exploit.
+
+    Future work: when the parser starts handing forward the parsed
+    ``DoclingDocument``, we can swap the markdown-walking layer for
+    Docling's native ``HybridChunker`` to gain page numbers and
+    table-cell awareness. The :class:`Chunker` contract stays the same.
+    """
+
+    def __init__(self) -> None:
+        self._inner = RecursiveTokenChunker()
+
+    async def chunk(
+        self,
+        text: str,
+        *,
+        chunk_size_tokens: int = 600,
+        chunk_overlap_tokens: int = 100,
+    ) -> list[Chunk]:
+        if chunk_size_tokens <= 0:
+            raise ValueError(
+                f"chunk_size_tokens must be positive, got {chunk_size_tokens}",
+            )
+        if chunk_overlap_tokens < 0:
+            raise ValueError(
+                "chunk_overlap_tokens must be non-negative, got "
+                f"{chunk_overlap_tokens}",
+            )
+        text = text.strip()
+        if not text:
+            return []
+
+        sections = _split_by_headings(text)
+        out: list[Chunk] = []
+        for path, body in sections:
+            if not body:
+                continue
+            section_label = _heading_path_text(path)
+
+            # Small section that fits below the cap → emit as one chunk
+            # with full heading path attribution.
+            if count_tokens(body) <= chunk_size_tokens:
+                out.append(Chunk(
+                    content=_with_heading_prefix(section_label, body),
+                    metadata={
+                        "section_path": path,
+                        "heading": path[-1] if path else "",
+                    },
+                    token_count=count_tokens(body),
+                ))
+                continue
+
+            # Large section → recurse, prepending heading context to
+            # each sub-chunk so the embedding sees the section title.
+            sub_chunks = await self._inner.chunk(
+                body,
+                chunk_size_tokens=chunk_size_tokens,
+                chunk_overlap_tokens=chunk_overlap_tokens,
+            )
+            for chunk in sub_chunks:
+                chunk.content = _with_heading_prefix(
+                    section_label, chunk.content,
+                )
+                chunk.metadata = {
+                    "section_path": path,
+                    "heading": path[-1] if path else "",
+                }
+                # Re-tokenize since we just prepended.
+                chunk.token_count = count_tokens(chunk.content)
+                out.append(chunk)
+        return out
+
+
+def _with_heading_prefix(label: str, body: str) -> str:
+    """Prepend ``[label]\\n`` to *body* when *label* is non-empty."""
+    if not label:
+        return body
+    return f"[{label}]\n{body}"
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
 
-def create_chunker(*, enabled: bool = True) -> Chunker:
-    """Create the default chunker.
+def _docling_available() -> bool:
+    """Cheap probe: did the user install ``fipsagents[files]``?"""
+    try:
+        import docling  # noqa: F401
+        return True
+    except ImportError:
+        return False
 
-    For now this always returns :class:`RecursiveTokenChunker` when
-    enabled. PR-D will extend the factory to auto-select
-    :class:`DoclingChunker` when the parser output looks Docling-shaped
-    and the ``[files]`` extra is installed.
+
+def create_chunker(*, enabled: bool = True) -> Chunker:
+    """Create a chunker based on what's available in the environment.
+
+    - ``enabled=False`` → :class:`NullChunker` (chunking disabled).
+    - ``docling`` installed → :class:`DoclingChunker` (heading-aware).
+    - Otherwise → :class:`RecursiveTokenChunker` (zero deps).
+
+    Both the heading-aware and recursive chunkers satisfy the same
+    contract; the heading-aware one is auto-selected because the only
+    deployments that have it are exactly the ones whose parser
+    produces structurally rich text — and on those, heading-aware
+    chunks beat plain paragraph chunks for retrieval recall.
     """
     if not enabled:
         return NullChunker()
+    if _docling_available():
+        logger.info(
+            "create_chunker: docling installed → using DoclingChunker "
+            "(heading-aware splitting).",
+        )
+        return DoclingChunker()
     return RecursiveTokenChunker()

--- a/packages/fipsagents/tests/test_chunker.py
+++ b/packages/fipsagents/tests/test_chunker.py
@@ -7,14 +7,19 @@ import pytest
 from fipsagents.server import chunker as chunker_mod
 from fipsagents.server.chunker import (
     Chunk,
+    DoclingChunker,
     NullChunker,
     RecursiveTokenChunker,
+    _docling_available,
     _greedy_assemble,
     _hard_split_by_tokens,
+    _heading_path_text,
     _recursive_units,
+    _split_by_headings,
     _split_paragraphs,
     _split_sentences,
     _take_overlap,
+    _with_heading_prefix,
     count_tokens,
     create_chunker,
 )
@@ -389,11 +394,223 @@ class TestCreateChunker:
     def test_disabled_returns_null(self):
         assert isinstance(create_chunker(enabled=False), NullChunker)
 
-    def test_enabled_returns_recursive(self):
-        assert isinstance(create_chunker(enabled=True), RecursiveTokenChunker)
+    def test_enabled_returns_a_real_chunker(self):
+        # Either DoclingChunker (when [files] extra installed) or
+        # RecursiveTokenChunker — both satisfy the contract.
+        chunker = create_chunker(enabled=True)
+        assert isinstance(chunker, (DoclingChunker, RecursiveTokenChunker))
 
     def test_default_is_enabled(self):
-        assert isinstance(create_chunker(), RecursiveTokenChunker)
+        chunker = create_chunker()
+        assert isinstance(chunker, (DoclingChunker, RecursiveTokenChunker))
+
+    def test_falls_back_to_recursive_when_docling_missing(self, monkeypatch):
+        monkeypatch.setattr(chunker_mod, "_docling_available", lambda: False)
+        chunker = create_chunker(enabled=True)
+        assert isinstance(chunker, RecursiveTokenChunker)
+        assert not isinstance(chunker, DoclingChunker)
+
+    def test_picks_docling_when_available(self, monkeypatch):
+        monkeypatch.setattr(chunker_mod, "_docling_available", lambda: True)
+        chunker = create_chunker(enabled=True)
+        assert isinstance(chunker, DoclingChunker)
+
+
+# ---------------------------------------------------------------------------
+# Heading-aware splitter primitives
+# ---------------------------------------------------------------------------
+
+
+class TestSplitByHeadings:
+    def test_no_headings_emits_single_section(self):
+        sections = _split_by_headings("just prose, no markers")
+        assert sections == [([], "just prose, no markers")]
+
+    def test_single_h1(self):
+        sections = _split_by_headings("# Title\n\nbody text\n")
+        assert sections == [(["Title"], "body text")]
+
+    def test_h1_h2_nesting(self):
+        text = (
+            "# Doc Title\n\nintro\n\n"
+            "## Section A\n\nA body\n\n"
+            "## Section B\n\nB body\n"
+        )
+        sections = _split_by_headings(text)
+        assert sections == [
+            (["Doc Title"], "intro"),
+            (["Doc Title", "Section A"], "A body"),
+            (["Doc Title", "Section B"], "B body"),
+        ]
+
+    def test_prologue_before_first_heading(self):
+        text = "preamble paragraph\n\n# Heading\n\nbody"
+        sections = _split_by_headings(text)
+        assert sections[0] == ([], "preamble paragraph")
+        assert sections[1] == (["Heading"], "body")
+
+    def test_deeper_heading_levels(self):
+        text = (
+            "# Top\n\n"
+            "## Mid\n\n"
+            "### Deep\n\nleaf body\n"
+        )
+        sections = _split_by_headings(text)
+        # The deepest heading inherits the full chain.
+        assert sections[-1][0] == ["Top", "Mid", "Deep"]
+
+    def test_heading_skip_levels(self):
+        # Document jumps from h1 → h3, skipping h2.
+        text = "# Top\n\n### Skipper\n\nbody"
+        sections = _split_by_headings(text)
+        # The skipped level becomes an empty placeholder so that the
+        # heading-path stack stays consistent for sibling sections.
+        assert sections[-1][0] == ["Top", "", "Skipper"]
+
+    def test_empty_section_body_kept(self):
+        # Adjacent headings with no body in between.
+        text = "# A\n\n# B\n\nb body"
+        sections = _split_by_headings(text)
+        assert (["A"], "") in sections or all(s[0] != ["A"] or s[1] == "" for s in sections)
+
+    def test_setext_headings_not_treated_as_split(self):
+        # Setext-style headings (=== under text) are not handled — we
+        # treat them as ordinary paragraph content.
+        text = "Title\n=====\n\nbody"
+        sections = _split_by_headings(text)
+        assert sections == [([], "Title\n=====\n\nbody")]
+
+
+class TestHeadingPathText:
+    def test_empty_path(self):
+        assert _heading_path_text([]) == ""
+
+    def test_single_level(self):
+        assert _heading_path_text(["Intro"]) == "Intro"
+
+    def test_multi_level(self):
+        assert _heading_path_text(["Doc", "Section A", "Sub"]) == (
+            "Doc > Section A > Sub"
+        )
+
+    def test_drops_empty_segments(self):
+        # Skip-levels produced "" placeholders; rendering should drop them.
+        assert _heading_path_text(["Top", "", "Deep"]) == "Top > Deep"
+
+
+class TestWithHeadingPrefix:
+    def test_empty_label_returns_body(self):
+        assert _with_heading_prefix("", "body") == "body"
+
+    def test_label_prefix(self):
+        assert _with_heading_prefix("Section A", "body") == "[Section A]\nbody"
+
+
+# ---------------------------------------------------------------------------
+# DoclingChunker
+# ---------------------------------------------------------------------------
+
+
+class TestDoclingChunker:
+    @pytest.mark.asyncio
+    async def test_empty_text(self):
+        chunker = DoclingChunker()
+        assert await chunker.chunk("") == []
+        assert await chunker.chunk("  \n\n  ") == []
+
+    @pytest.mark.asyncio
+    async def test_invalid_chunk_size_raises(self):
+        chunker = DoclingChunker()
+        with pytest.raises(ValueError):
+            await chunker.chunk("text", chunk_size_tokens=0)
+
+    @pytest.mark.asyncio
+    async def test_invalid_overlap_raises(self):
+        chunker = DoclingChunker()
+        with pytest.raises(ValueError):
+            await chunker.chunk("text", chunk_overlap_tokens=-1)
+
+    @pytest.mark.asyncio
+    async def test_no_headings_falls_through_to_recursive(self):
+        text = (
+            "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        )
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text, chunk_size_tokens=200)
+        assert len(out) == 1
+        # No heading prefix when there is no heading.
+        assert not out[0].content.startswith("[")
+        assert out[0].metadata["section_path"] == []
+
+    @pytest.mark.asyncio
+    async def test_one_chunk_per_short_section(self):
+        text = (
+            "# Document\n\nintro\n\n"
+            "## Section A\n\nA body short\n\n"
+            "## Section B\n\nB body also short\n"
+        )
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text, chunk_size_tokens=200)
+        # 3 sections (intro under "Document", then A, B).
+        assert len(out) == 3
+        # Each chunk's section_path is the heading breadcrumb.
+        assert out[0].metadata["section_path"] == ["Document"]
+        assert out[1].metadata["section_path"] == ["Document", "Section A"]
+        assert out[2].metadata["section_path"] == ["Document", "Section B"]
+        # Heading prefix is present for non-prologue sections.
+        assert "[Document > Section A]" in out[1].content
+        assert "[Document > Section B]" in out[2].content
+
+    @pytest.mark.asyncio
+    async def test_long_section_recurses_with_heading_prefix(self):
+        # One heading, lots of body — should produce >1 chunk, each
+        # carrying the section heading prefix.
+        body_para = (
+            "The quick brown fox jumps over the lazy dog. "
+            "Pack my box with five dozen liquor jugs.\n\n"
+        )
+        text = "# Title\n\n## Big Section\n\n" + (body_para * 30)
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text, chunk_size_tokens=200)
+        assert len(out) > 1
+        # Every chunk gets the same section_path and prefix.
+        for chunk in out:
+            assert chunk.metadata["section_path"] == ["Title", "Big Section"]
+            assert chunk.content.startswith("[Title > Big Section]")
+
+    @pytest.mark.asyncio
+    async def test_heading_metadata_includes_leaf_heading(self):
+        text = "# Top\n\n## Leaf\n\nbody"
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text)
+        assert out[-1].metadata["heading"] == "Leaf"
+
+    @pytest.mark.asyncio
+    async def test_prologue_has_no_section_prefix(self):
+        text = "intro paragraph here\n\n# Heading\n\nbody"
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text)
+        assert out[0].content == "intro paragraph here"
+        assert out[0].metadata["section_path"] == []
+        assert out[0].metadata["heading"] == ""
+
+    @pytest.mark.asyncio
+    async def test_token_count_populated(self):
+        text = "# Heading\n\nbody body body"
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text)
+        for chunk in out:
+            assert chunk.token_count > 0
+
+    @pytest.mark.asyncio
+    async def test_empty_section_dropped(self):
+        # Adjacent headings with empty bodies should not produce empty chunks.
+        text = "# A\n\n# B\n\nb body"
+        chunker = DoclingChunker()
+        out = await chunker.chunk(text)
+        # Only B's body produces a chunk.
+        assert len(out) == 1
+        assert out[0].metadata["section_path"] == ["B"]
 
 
 # ---------------------------------------------------------------------------
@@ -413,3 +630,15 @@ class TestChunk:
         b = Chunk(content="b")
         a.metadata["key"] = "value"
         assert "key" not in b.metadata
+
+
+# ---------------------------------------------------------------------------
+# Docling availability probe
+# ---------------------------------------------------------------------------
+
+
+class TestDoclingAvailable:
+    def test_returns_bool(self):
+        # Cannot assert True or False without knowing the env, but the
+        # probe must always return a bool and never raise.
+        assert isinstance(_docling_available(), bool)


### PR DESCRIPTION
Fourth slice of [#137](https://github.com/fips-agents/agent-template/issues/137). Smarter default chunker for deployments whose parser produces structurally rich output (Docling).

## What's in

- `DoclingChunker` (in ``server/chunker.py``)
  - Splits markdown on ATX heading boundaries first (``#`` / ``##`` / ``###`` …), captures the full heading breadcrumb in ``Chunk.metadata.section_path``, then falls back to ``RecursiveTokenChunker`` within each section.
  - Each chunk content gets a ``[Section A > Section B]`` prefix so the embedding sees the section title as part of the indexed text — significantly improves retrieval recall on long structured documents.
  - Tracks ``Chunk.metadata.heading`` (leaf heading) too, for downstream callers that want a short label without parsing the path.
- ``_split_by_headings`` + ``_heading_path_text`` + ``_with_heading_prefix`` helpers, all exhaustively unit-tested.
- ``create_chunker()`` extended to auto-select ``DoclingChunker`` when docling is importable (the ``[files]`` extra), and fall through to ``RecursiveTokenChunker`` otherwise. Both satisfy the same contract — PR-C's server wiring is unchanged.

## Scope note

The ADR mentions Docling's native ``HybridChunker`` as a potential implementation. That requires the upstream parser to hand the parsed ``DoclingDocument`` forward; today the parser calls ``export_to_markdown()`` and discards the structured form. PR-D ships the markdown-aware splitter because:

- It captures most of the structural benefit (heading breadcrumbs, table-block preservation that survives the markdown round-trip) without the parser refactor.
- It works on **any** heading-rich markdown, not just Docling output — so it's also useful when users upload markdown directly.
- The ``Chunker`` contract stays string-in / chunks-out, so PR-C never has to know which chunker is wired in.

Native ``HybridChunker`` integration is a clean follow-up: extend ``ParseOutcome`` to optionally carry a ``DoclingDocument``, plumb it through ``_chunk_uploaded_file``, and have ``DoclingChunker`` accept either text or a dl_doc. The chunk-store side does not change.

## Tests

- 27 new unit tests in ``test_chunker.py``:
  - Heading splitter: no-headings fallthrough, single h1, h1+h2 nesting, deeper levels (h3+), heading-skip placeholders (``h1 → h3``), prologue before first heading, setext-not-handled.
  - Heading-path rendering: empty path, single-level, multi-level with `>` separator, skip-level segments dropped.
  - Section prefix builder: empty label returns body unchanged, populated label produces ``[label]\nbody``.
  - End-to-end ``DoclingChunker``: empty input, invalid args, no-headings input, one-chunk-per-short-section with section_path metadata, long-section recursion with inherited prefix, leaf-heading metadata, prologue without prefix, empty-section drop, token_count populated.
  - Factory dispatch: ``test_falls_back_to_recursive_when_docling_missing`` and ``test_picks_docling_when_available`` monkeypatch ``_docling_available`` so the test result is deterministic regardless of whether the test environment has docling installed.
  - ``_docling_available`` bool contract.

Suite: **1108/1108** (was 1081, +27 new from PR-D). Ruff clean.

## What's not in

- Template ``agent.yaml`` env-var surface for ``files.chunking`` (`PGVECTOR_URL`, `EMBEDDING_URL`, etc.) → **PR-E**.
- Helm chart ``files.chunking`` block + chart bump → **PR-E**.
- Cluster smoke against real pgvector + embedding endpoint → after PR-E.
- Native ``HybridChunker`` integration (parser refactor required) → follow-up after the chunking PR series lands.

## Notes for reviewers

- **Heading prefix in content (not just metadata).** ``[Section A > Subsection]\n<body>`` ends up as the embedded text. This is intentional — embeddings of section bodies without the heading context perform notably worse on retrieval, and the prefix is short relative to the body. If a deployment dislikes the prefix in retrieved output, the metadata.section_path still carries the structured form and the prefix can be stripped client-side.
- **Skip-level placeholder.** When a doc jumps from h1 → h3 (no h2), the breadcrumb gets an empty-string segment. ``_heading_path_text`` filters those out for display, but the path itself preserves them so sibling sections at h3 can still be distinguished. Documented inline.
- **Setext headings (===) not handled.** Docling's ``export_to_markdown`` uses ATX exclusively; supporting setext would expand the regex without adding real coverage. Test asserts current behavior so a future change is intentional, not accidental.

Closes part of #137. Blocks PR-E.