### PR TITLE
feat(template): expose files.chunking in agent.yaml + Helm chart (PR-E of #137)

### DIFF
--- a/templates/agent-loop/agent.yaml
+++ b/templates/agent-loop/agent.yaml
@@ -324,6 +324,60 @@ server:
       timeout_seconds: 30.0
       fail_mode: ${FILES_SCANNER_FAIL_MODE:-open}
 
+    # -- Large-file chunking + retrieval (optional, per ADR-0002) ------------
+    #
+    # When enabled, files whose extracted text exceeds
+    # `small_file_threshold_tokens` are split into chunks, embedded via the
+    # configured OpenAI-compatible embedding endpoint, and stored in
+    # pgvector. At chat-completion time the chunked file's content is
+    # retrieved per-query (top-K nearest chunks scoped to the user's
+    # `file_ids`) instead of dumping the full text into the prompt.
+    #
+    # Disabled by default — flip `enabled: true` and provide a pgvector URL
+    # + embedding endpoint to opt in. Files smaller than the threshold and
+    # files uploaded while chunking is disabled fall back to full-text
+    # injection (the 0.17.0 behaviour).
+    #
+    # `backend: pgvector` requires the [chunking] extra in the container
+    # build (`pip install fipsagents[chunking]`).
+    #
+    # Budget presets parallel `memory.budget` so a deployment using
+    # `${MEMORY_BUDGET}` for memory naturally gets matching chunking
+    # defaults — set `${CHUNKING_BUDGET}` to the same value:
+    #   small   -- chunk_size_tokens=400, retrieval_top_k=3,
+    #              small_file_threshold_tokens=2000
+    #   medium  -- 600 / 5  / 4000     (default sizing)
+    #   large   -- 800 / 8  / 8000
+    #   custom  -- no preset; set the per-tier knobs explicitly
+    #
+    # Production env vars:
+    #   CHUNKING_ENABLED          -- "true" to enable
+    #   CHUNKING_BACKEND          -- "pgvector" (default "null" = disabled)
+    #   PGVECTOR_URL              -- Postgres+pgvector connection string
+    #                                (postgresql://user:pass@host:5432/db)
+    #   EMBEDDING_URL             -- OpenAI-compatible embeddings endpoint
+    #   EMBEDDING_MODEL           -- model identifier passed to the endpoint
+    #   EMBEDDING_DIMENSION       -- vector dim (must match the model)
+    #   CHUNKING_TABLE            -- pgvector table name (default file_chunks)
+    #   CHUNKING_BUDGET           -- "small" | "medium" | "large" | "custom"
+    chunking:
+      enabled: ${CHUNKING_ENABLED:-false}
+      # Quoted so the default stays the literal string "null" — Pydantic's
+      # Literal["null", "pgvector"] rejects YAML's bare null (None).
+      backend: "${CHUNKING_BACKEND:-null}"
+      database_url: "${PGVECTOR_URL:-}"
+      embedding_url: "${EMBEDDING_URL:-}"
+      embedding_model: "${EMBEDDING_MODEL:-all-MiniLM-L6-v2}"
+      embedding_dimension: ${EMBEDDING_DIMENSION:-768}
+      table_name: "${CHUNKING_TABLE:-file_chunks}"
+      # budget: ${CHUNKING_BUDGET:-medium}
+      # Per-tier knobs (override the budget preset):
+      # chunk_size_tokens: 600
+      # chunk_overlap_tokens: 100
+      # small_file_threshold_tokens: 4000
+      # retrieval_top_k: 5
+      # retrieval_min_score: 0.0
+
 # -- Memory backend (optional) -----------------------------------------------
 #
 # Controls which memory backend the agent uses.

--- a/templates/agent-loop/chart/Chart.yaml
+++ b/templates/agent-loop/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: agent-template
 description: Helm chart for deploying a BaseAgent to OpenShift
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.9.0
+appVersion: 0.9.0
 type: application

--- a/templates/agent-loop/chart/templates/deployment.yaml
+++ b/templates/agent-loop/chart/templates/deployment.yaml
@@ -128,6 +128,43 @@ spec:
               value: "true"
             {{- end }}
             {{- end }}
+            {{- if .Values.files.chunking.enabled }}
+            # Large-file chunking + retrieval (per ADR-0002). When enabled,
+            # files >small_file_threshold_tokens are chunked, embedded via
+            # the configured embedding endpoint, and stored in pgvector for
+            # per-query retrieval. Disabled deployments fall through to the
+            # 0.17.0 full-text injection path.
+            - name: CHUNKING_ENABLED
+              value: "true"
+            {{- if .Values.files.chunking.backend }}
+            - name: CHUNKING_BACKEND
+              value: {{ .Values.files.chunking.backend | quote }}
+            {{- end }}
+            {{- if .Values.files.chunking.databaseUrl }}
+            - name: PGVECTOR_URL
+              value: {{ .Values.files.chunking.databaseUrl | quote }}
+            {{- end }}
+            {{- if .Values.files.chunking.embeddingUrl }}
+            - name: EMBEDDING_URL
+              value: {{ .Values.files.chunking.embeddingUrl | quote }}
+            {{- end }}
+            {{- if .Values.files.chunking.embeddingModel }}
+            - name: EMBEDDING_MODEL
+              value: {{ .Values.files.chunking.embeddingModel | quote }}
+            {{- end }}
+            {{- if .Values.files.chunking.embeddingDimension }}
+            - name: EMBEDDING_DIMENSION
+              value: {{ .Values.files.chunking.embeddingDimension | quote }}
+            {{- end }}
+            {{- if .Values.files.chunking.tableName }}
+            - name: CHUNKING_TABLE
+              value: {{ .Values.files.chunking.tableName | quote }}
+            {{- end }}
+            {{- if .Values.files.chunking.budget }}
+            - name: CHUNKING_BUDGET
+              value: {{ .Values.files.chunking.budget | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
           {{- end }}
           {{- if and .Values.files.enabled .Values.files.persistence.enabled }}

--- a/templates/agent-loop/chart/values.yaml
+++ b/templates/agent-loop/chart/values.yaml
@@ -206,6 +206,35 @@ files:
     secretKey: ""
     prefix: ""                # optional key prefix within the bucket
     pathStyle: false
+  # Large-file chunking + retrieval (per ADR-0002). When enabled, files
+  # whose extracted text exceeds small_file_threshold_tokens are split,
+  # embedded via the configured OpenAI-compatible embedding endpoint,
+  # and stored in pgvector. At chat-completion time the chunked file's
+  # content is retrieved per-query rather than dumped wholesale into the
+  # prompt — the canonical RAG path scoped to the request's file_ids.
+  #
+  # Disabled by default; smaller files always inject as full text.
+  # Enable to opt this deployment into chunking — requires:
+  #   - the [chunking] extra in the container build
+  #   - a reachable pgvector instance (databaseUrl)
+  #   - a reachable OpenAI-compatible embeddings endpoint (embeddingUrl)
+  #
+  # The chart sets CHUNKING_* env vars on the agent container when
+  # enabled; the in-image agent.yaml's files.chunking block resolves
+  # them. Empty values defer to the agent.yaml defaults.
+  #
+  # budget mirrors memory.budget so a deployment using `budget: small`
+  # for memory naturally gets matching chunking defaults — set the same
+  # value here for parity.
+  chunking:
+    enabled: false
+    backend: pgvector            # "" | pgvector | null
+    databaseUrl: ""              # postgresql://user:pass@host:5432/db
+    embeddingUrl: ""             # eg http://embedding.<ns>.svc/v1
+    embeddingModel: ""           # empty defers to agent.yaml default
+    embeddingDimension: ""       # empty defers to agent.yaml default (768)
+    tableName: ""                # empty defers to agent.yaml default
+    budget: ""                   # "" | small | medium | large | custom
   # ClamAV sidecar — pre-deployed image with an HTTP shim that the
   # framework's HttpScanner contract expects.
   virusScanner:

--- a/templates/agent-loop/tests/test_template_render.py
+++ b/templates/agent-loop/tests/test_template_render.py
@@ -1,0 +1,125 @@
+"""Render-tests for the scaffolded ``agent.yaml`` template.
+
+The template ships with a commented-out files.chunking block that
+operators flip on by setting CHUNKING_ENABLED + the matching
+PGVECTOR_URL / EMBEDDING_URL env vars. These tests load the actual
+``templates/agent-loop/agent.yaml`` file through ``AgentConfig`` and
+assert that env-var substitution lands the chunking knobs in the right
+place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fipsagents.baseagent.config import AgentConfig, load_config
+
+TEMPLATE_AGENT_YAML = Path(__file__).resolve().parents[1] / "agent.yaml"
+
+
+@pytest.fixture(scope="module")
+def template_path() -> Path:
+    assert TEMPLATE_AGENT_YAML.is_file(), (
+        f"Template agent.yaml not found at {TEMPLATE_AGENT_YAML}"
+    )
+    return TEMPLATE_AGENT_YAML
+
+
+class TestChunkingDefaults:
+    """Default deployment: chunking off, files off."""
+
+    def test_loads_with_no_env(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert isinstance(cfg, AgentConfig)
+
+    def test_chunking_disabled_by_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert cfg.server.files.chunking.enabled is False
+
+    def test_chunking_backend_null_by_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert cfg.server.files.chunking.backend == "null"
+
+    def test_embedding_url_empty_by_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert cfg.server.files.chunking.database_url == ""
+        assert cfg.server.files.chunking.embedding_url == ""
+
+    def test_embedding_model_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        # Mirrors ChunkingConfig.embedding_model default.
+        assert cfg.server.files.chunking.embedding_model == "all-MiniLM-L6-v2"
+
+    def test_embedding_dimension_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert cfg.server.files.chunking.embedding_dimension == 768
+
+    def test_table_name_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert cfg.server.files.chunking.table_name == "file_chunks"
+
+
+class TestChunkingEnabled:
+    """A real production deployment flips the env vars on."""
+
+    @pytest.fixture
+    def env(self) -> dict[str, str]:
+        return {
+            "CHUNKING_ENABLED": "true",
+            "CHUNKING_BACKEND": "pgvector",
+            "PGVECTOR_URL": "postgresql://chunks:secret@pgv:5432/chunks",
+            "EMBEDDING_URL": "http://embedding.platform.svc/v1",
+            "EMBEDDING_MODEL": "BAAI/bge-small-en-v1.5",
+            "EMBEDDING_DIMENSION": "384",
+            "CHUNKING_TABLE": "agent_file_chunks",
+        }
+
+    def test_chunking_enabled(self, template_path: Path, env: dict[str, str]):
+        cfg = load_config(template_path, env=env)
+        assert cfg.server.files.chunking.enabled is True
+
+    def test_chunking_backend_pgvector(self, template_path: Path, env: dict[str, str]):
+        cfg = load_config(template_path, env=env)
+        assert cfg.server.files.chunking.backend == "pgvector"
+
+    def test_database_url_propagates(self, template_path: Path, env: dict[str, str]):
+        cfg = load_config(template_path, env=env)
+        assert (
+            cfg.server.files.chunking.database_url
+            == "postgresql://chunks:secret@pgv:5432/chunks"
+        )
+
+    def test_embedding_url_propagates(self, template_path: Path, env: dict[str, str]):
+        cfg = load_config(template_path, env=env)
+        assert (
+            cfg.server.files.chunking.embedding_url
+            == "http://embedding.platform.svc/v1"
+        )
+
+    def test_embedding_model_propagates(self, template_path: Path, env: dict[str, str]):
+        cfg = load_config(template_path, env=env)
+        assert cfg.server.files.chunking.embedding_model == "BAAI/bge-small-en-v1.5"
+
+    def test_embedding_dimension_coerces(self, template_path: Path, env: dict[str, str]):
+        # Env vars are strings; ChunkingConfig must coerce to int.
+        cfg = load_config(template_path, env=env)
+        assert cfg.server.files.chunking.embedding_dimension == 384
+
+    def test_table_name_propagates(self, template_path: Path, env: dict[str, str]):
+        cfg = load_config(template_path, env=env)
+        assert cfg.server.files.chunking.table_name == "agent_file_chunks"
+
+
+class TestFilesBlockUnaffected:
+    """Adding chunking should not change the files block defaults."""
+
+    def test_files_disabled_by_default(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        assert cfg.server.files.enabled is False
+
+    def test_files_default_max_size(self, template_path: Path):
+        cfg = load_config(template_path, env={})
+        # 50 MiB — preserved from the FilesConfig default.
+        assert cfg.server.files.max_file_size_bytes == 50 * 1024 * 1024


### PR DESCRIPTION
## Summary

Surfaces the large-file chunking + pgvector retrieval feature from PRs A–D so operators can opt into it from a deployment, not just from framework code.

- `templates/agent-loop/agent.yaml` gains a `files.chunking` block under `server.files` with `${CHUNKING_ENABLED:-false}`, `${PGVECTOR_URL}`, `${EMBEDDING_URL}`, `${EMBEDDING_MODEL}`, `${EMBEDDING_DIMENSION}`, `${CHUNKING_TABLE}`, `${CHUNKING_BUDGET}`. Defaults mirror `ChunkingConfig` — disabled, backend `"null"`, 768-dim `all-MiniLM-L6-v2`, table `file_chunks`. The block documents the parallel to `${MEMORY_BUDGET}`.
- `templates/agent-loop/chart/values.yaml` mirrors the block under `files.chunking` (defaults `enabled: false`); `deployment.yaml` wires `CHUNKING_*` env vars on the agent container when `files.chunking.enabled`.
- Chart bumped 0.8.0 → 0.9.0.
- New `tests/test_template_render.py` loads the actual template `agent.yaml` through `AgentConfig` and asserts the chunking knobs land in the right place — 16 cases covering defaults, env-var overrides, coercion (`EMBEDDING_DIMENSION="384"` → `int`), and that the existing files block is unaffected.

## Notes

- The render test caught a bug: `backend: ${CHUNKING_BACKEND:-null}` resolved to YAML `null` (Python `None`), which `Literal["null", "pgvector"]` rejects. Quoting the default — `backend: "${CHUNKING_BACKEND:-null}"` — keeps it the literal string `"null"`. Same fix applied to other string-typed defaults to stay consistent with the existing `bytes_backend.type` quoting.
- **Workflow template intentionally not changed**: it has no `server:` block yet (no files / sessions / traces / feedback). Bringing it to parity is its own follow-up — out of PR-E scope.

## Test plan

- [x] `pytest packages/fipsagents/tests/` — 1173 passed, 18 skipped
- [x] `pytest templates/agent-loop/tests/ --ignore=tests/test_example_agent.py` — 345 passed (incl. 16 new render tests). The skipped file has a pre-existing `ModuleNotFoundError` on `main`, unrelated.
- [x] `helm lint templates/agent-loop/chart` — clean (icon-recommended only)
- [x] `ruff check` — clean
- [x] `gitleaks detect` from repo root — no leaks

Refs: #137 (closes track A–D + E ship plan)