### PR TITLE
release: fipsagents 0.18.0 — large-file chunking + pgvector retrieval

### DIFF
--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fipsagents"
-version = "0.17.0"
+version = "0.18.0"
 description = "Production-ready AI agent framework for FIPS/OpenShift environments"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary

Bumps `packages/fipsagents/pyproject.toml` from 0.17.0 → 0.18.0.

The headline change since 0.17.0 is the opt-in large-file chunking + pgvector retrieval path for uploaded files (ADR-0002, #137). Disabled by default — existing deployments behave identically until `files.chunking.enabled: true` is set per-deployment.

### What's in 0.18.0

- Chunker ABC + RecursiveTokenChunker (#139)
- ChunkStore ABC + PgvectorChunkStore (#140)
- Server wiring: async chunking on upload, top-K retrieval per request, three-way fallback to full-text, DELETE cascade (#141)
- Heading-aware DoclingChunker + auto-selection (#142)
- Operator surface: `files.chunking` in `agent.yaml` + Helm chart 0.9.0 (#143)
- Docs: chunking + file-uploads sections in `CLAUDE.md` and `docs/architecture.md` (#144)

### Release process

`publish.yml` publishes to PyPI on the `fipsagents-v0.18.0` tag (OIDC trusted publishing). After this PR merges, tag from `main`.

## Test plan

- [x] `packages/fipsagents/tests/` — 1173 passed / 18 skipped (137 s) at session-close on `main`
- [x] `templates/agent-loop/tests/` — 345 passed (with the known pre-existing `test_example_agent.py` collection error)
- [x] `helm lint templates/agent-loop/chart` — clean
- [x] `ruff check` — clean
- [x] `gitleaks` — clean
- [ ] Cluster smoke against `fipsagents-files-smoke` namespace after the tag publishes