### PR TITLE
fix(server): expose Docling PDF pipeline knobs on FilesConfig

### DIFF
--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -523,6 +523,34 @@ class BytesBackendConfig(BaseModel):
     path_style: bool = False
 
 
+class PdfParserConfig(BaseModel):
+    """Docling PDF pipeline knobs.
+
+    Maps directly onto :class:`docling.datamodel.pipeline_options.PdfPipelineOptions`.
+    Only the high-impact fields are surfaced; other Docling defaults are
+    used as-is.
+
+    ``do_ocr=False`` is the framework default (changed in 0.19.0). Most
+    modern PDFs ship a selectable text layer and OCR adds 1-2 seconds
+    per page on a 2-CPU pod with no quality benefit. Operators with
+    scanned PDFs flip it back on.
+    """
+
+    do_ocr: bool = False
+    do_table_structure: bool = True
+
+
+class ParserConfig(BaseModel):
+    """File-parser settings.
+
+    Currently only PDF has a Docling-specific pipeline; other formats
+    use the converter defaults. Sub-blocks (``docx``, ``pptx``, ...)
+    can be added without breaking existing configs.
+    """
+
+    pdf: PdfParserConfig = Field(default_factory=PdfParserConfig)
+
+
 class ChunkingConfig(BaseModel):
     """Large-file chunking + retrieval settings (per ADR-0002).
 
@@ -612,6 +640,11 @@ class FilesConfig(_PerStoreBackendMixin):
     ADR-0002). Disabled by default; enable to chunk large files at
     upload time and retrieve only the relevant chunks at chat-completion
     time instead of injecting the full extracted text.
+
+    ``parser`` exposes Docling pipeline knobs. The 0.19.0 default flips
+    ``parser.pdf.do_ocr`` to ``False`` -- text-extractable PDFs parse in
+    sub-second instead of multiple minutes. Operators with scanned
+    PDFs set ``do_ocr: true``.
     """
 
     enabled: bool = False
@@ -622,6 +655,7 @@ class FilesConfig(_PerStoreBackendMixin):
     allowed_mime_types: list[str] = Field(default_factory=list)
     max_age_hours: int = Field(default=720, ge=0)
     scanner: ScannerConfig = Field(default_factory=ScannerConfig)
+    parser: ParserConfig = Field(default_factory=ParserConfig)
     chunking: ChunkingConfig = Field(default_factory=ChunkingConfig)
 
 

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -284,6 +284,7 @@ class OpenAIChatServer:
         )
         self._file_parser = create_parser(
             enabled=server_cfg.files.enabled,
+            parser_config=server_cfg.files.parser,
         )
         self._virus_scanner = create_scanner(
             url=server_cfg.files.scanner.url,

--- a/packages/fipsagents/src/fipsagents/server/parser.py
+++ b/packages/fipsagents/src/fipsagents/server/parser.py
@@ -24,6 +24,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fipsagents.baseagent.config import ParserConfig
 
 logger = logging.getLogger(__name__)
 
@@ -156,11 +160,17 @@ class DoclingParser(FileParser):
 
     Falls through to plaintext if the input looks text-shaped, since
     Docling's pipeline is overkill (and slow) for ``.txt`` / ``.md``.
+
+    ``parser_config`` controls Docling pipeline options (currently the
+    PDF pipeline's ``do_ocr`` and ``do_table_structure``). When omitted
+    the framework defaults from :class:`PdfParserConfig` apply
+    (``do_ocr=False`` -- text-extractable PDFs parse without OCR).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, parser_config: "ParserConfig | None" = None) -> None:
         self._converter: object | None = None
         self._plaintext = PlaintextParser()
+        self._parser_config = parser_config
 
     def _ensure_converter(self) -> object:
         if self._converter is not None:
@@ -174,8 +184,37 @@ class DoclingParser(FileParser):
                 "DoclingParser requires the [files] extra. "
                 "Install with: pip install 'fipsagents[files]'"
             ) from exc
-        self._converter = DocumentConverter()
+        format_options = self._build_format_options()
+        if format_options:
+            self._converter = DocumentConverter(format_options=format_options)
+        else:
+            self._converter = DocumentConverter()
         return self._converter
+
+    def _build_format_options(self) -> dict | None:
+        """Translate ``ParserConfig`` into Docling ``format_options``.
+
+        Returns ``None`` when no config was provided so we preserve the
+        no-arg ``DocumentConverter()`` path for callers that don't care
+        about pipeline tuning (and for tests that pre-inject a fake
+        converter via ``self._converter``).
+        """
+        if self._parser_config is None:
+            return None
+        try:
+            from docling.datamodel.base_models import InputFormat
+            from docling.datamodel.pipeline_options import PdfPipelineOptions
+            from docling.document_converter import PdfFormatOption
+        except ImportError:  # pragma: no cover — handled by _ensure_converter
+            return None
+        pdf_cfg = self._parser_config.pdf
+        pipeline_options = PdfPipelineOptions(
+            do_ocr=pdf_cfg.do_ocr,
+            do_table_structure=pdf_cfg.do_table_structure,
+        )
+        return {
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+        }
 
     async def parse(
         self, data: bytes, *, mime_type: str, filename: str,
@@ -250,18 +289,27 @@ def _docling_available() -> bool:
         return False
 
 
-def create_parser(*, enabled: bool = True) -> FileParser:
+def create_parser(
+    *,
+    enabled: bool = True,
+    parser_config: "ParserConfig | None" = None,
+) -> FileParser:
     """Create a parser based on what's available in the environment.
 
     - ``enabled=False`` → :class:`NullParser` (every file marked skipped).
     - ``docling`` installed → :class:`DoclingParser` (handles plaintext
       internally too).
     - Otherwise → :class:`PlaintextParser` (binaries get marked skipped).
+
+    ``parser_config`` is forwarded to :class:`DoclingParser` to apply
+    Docling pipeline tuning (e.g. ``parser.pdf.do_ocr``). It is silently
+    ignored when the resolved parser does not consume it, so callers can
+    pass it unconditionally regardless of the host's installed extras.
     """
     if not enabled:
         return NullParser()
     if _docling_available():
-        return DoclingParser()
+        return DoclingParser(parser_config=parser_config)
     logger.info(
         "create_parser: docling not installed; binary formats will be "
         "skipped. Install fipsagents[files] for PDF/DOCX/etc support.",

--- a/packages/fipsagents/tests/test_files_parser.py
+++ b/packages/fipsagents/tests/test_files_parser.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import sys
+import types
 
 import pytest
 
+from fipsagents.baseagent.config import ParserConfig, PdfParserConfig
 from fipsagents.server.parser import (
     DoclingParser,
     FileParser,
@@ -289,3 +291,129 @@ class TestCreateParser:
         or not, factory must return a usable FileParser."""
         parser = create_parser(enabled=True)
         assert isinstance(parser, FileParser)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline option propagation (issue #146)
+# ---------------------------------------------------------------------------
+
+
+class _FakeInputFormat:
+    PDF = "pdf-marker"
+
+
+class _FakePdfPipelineOptions:
+    def __init__(self, *, do_ocr, do_table_structure):
+        self.do_ocr = do_ocr
+        self.do_table_structure = do_table_structure
+
+
+class _FakePdfFormatOption:
+    def __init__(self, *, pipeline_options):
+        self.pipeline_options = pipeline_options
+
+
+class _RecordingDocumentConverter:
+    instances: list["_RecordingDocumentConverter"] = []
+
+    def __init__(self, format_options=None):
+        self.format_options = format_options
+        type(self).instances.append(self)
+
+
+@pytest.fixture
+def fake_docling(monkeypatch):
+    """Inject minimal docling stand-ins so DoclingParser._ensure_converter
+    can run without the [files] extra installed.
+
+    Resets the per-test instance log so each test starts clean.
+    """
+    docling_pkg = types.ModuleType("docling")
+    datamodel_pkg = types.ModuleType("docling.datamodel")
+    base_models = types.ModuleType("docling.datamodel.base_models")
+    base_models.InputFormat = _FakeInputFormat
+    pipeline_options = types.ModuleType("docling.datamodel.pipeline_options")
+    pipeline_options.PdfPipelineOptions = _FakePdfPipelineOptions
+    document_converter = types.ModuleType("docling.document_converter")
+    document_converter.DocumentConverter = _RecordingDocumentConverter
+    document_converter.PdfFormatOption = _FakePdfFormatOption
+
+    monkeypatch.setitem(sys.modules, "docling", docling_pkg)
+    monkeypatch.setitem(sys.modules, "docling.datamodel", datamodel_pkg)
+    monkeypatch.setitem(
+        sys.modules, "docling.datamodel.base_models", base_models,
+    )
+    monkeypatch.setitem(
+        sys.modules, "docling.datamodel.pipeline_options", pipeline_options,
+    )
+    monkeypatch.setitem(
+        sys.modules, "docling.document_converter", document_converter,
+    )
+    _RecordingDocumentConverter.instances = []
+    yield _RecordingDocumentConverter
+    _RecordingDocumentConverter.instances = []
+
+
+class TestPipelineOptions:
+    def test_default_config_flips_do_ocr_off(self):
+        """Framework default is do_ocr=False (issue #146)."""
+        cfg = ParserConfig()
+        assert cfg.pdf.do_ocr is False
+        assert cfg.pdf.do_table_structure is True
+
+    def test_no_config_keeps_no_args_constructor(self, fake_docling):
+        """Backward-compat path: DoclingParser() with no config builds
+        DocumentConverter() with no args, leaving Docling's own defaults
+        in place."""
+        parser = DoclingParser()
+        parser._ensure_converter()
+        assert len(fake_docling.instances) == 1
+        assert fake_docling.instances[0].format_options is None
+
+    @pytest.mark.parametrize("do_ocr", [True, False])
+    @pytest.mark.parametrize("do_table_structure", [True, False])
+    def test_pdf_options_propagate_to_converter(
+        self, fake_docling, do_ocr, do_table_structure,
+    ):
+        cfg = ParserConfig(
+            pdf=PdfParserConfig(
+                do_ocr=do_ocr, do_table_structure=do_table_structure,
+            ),
+        )
+        parser = DoclingParser(parser_config=cfg)
+        parser._ensure_converter()
+
+        assert len(fake_docling.instances) == 1
+        format_options = fake_docling.instances[0].format_options
+        assert format_options is not None
+        assert _FakeInputFormat.PDF in format_options
+
+        pdf_format_option = format_options[_FakeInputFormat.PDF]
+        options = pdf_format_option.pipeline_options
+        assert options.do_ocr is do_ocr
+        assert options.do_table_structure is do_table_structure
+
+    def test_factory_forwards_parser_config(self, monkeypatch, fake_docling):
+        monkeypatch.setattr(
+            "fipsagents.server.parser._docling_available", lambda: True,
+        )
+        cfg = ParserConfig(pdf=PdfParserConfig(do_ocr=True))
+        parser = create_parser(enabled=True, parser_config=cfg)
+        assert isinstance(parser, DoclingParser)
+
+        # Lazy-load to confirm the config reaches DocumentConverter.
+        parser._ensure_converter()
+        assert len(fake_docling.instances) == 1
+        options = fake_docling.instances[0].format_options[_FakeInputFormat.PDF]
+        assert options.pipeline_options.do_ocr is True
+
+    def test_factory_without_config_omits_format_options(
+        self, monkeypatch, fake_docling,
+    ):
+        monkeypatch.setattr(
+            "fipsagents.server.parser._docling_available", lambda: True,
+        )
+        parser = create_parser(enabled=True)
+        assert isinstance(parser, DoclingParser)
+        parser._ensure_converter()
+        assert fake_docling.instances[0].format_options is None

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -113,6 +113,12 @@ class _StubAgent(BaseAgent):
                         timeout_seconds=30.0,
                         fail_mode="open",
                     ),
+                    parser=types.SimpleNamespace(
+                        pdf=types.SimpleNamespace(
+                            do_ocr=False,
+                            do_table_structure=True,
+                        ),
+                    ),
                     chunking=types.SimpleNamespace(
                         enabled=False,
                         backend="null",

--- a/templates/agent-loop/agent.yaml
+++ b/templates/agent-loop/agent.yaml
@@ -324,6 +324,25 @@ server:
       timeout_seconds: 30.0
       fail_mode: ${FILES_SCANNER_FAIL_MODE:-open}
 
+    # -- Docling parser pipeline knobs --------------------------------------
+    #
+    # Tunes the Docling DocumentConverter used by `[files]`-extra builds.
+    # Currently only PDF has knobs surfaced; other formats use Docling's
+    # converter defaults.
+    #
+    # `parser.pdf.do_ocr` defaults to `false` in 0.19.0+. Most modern PDFs
+    # ship a selectable text layer; OCR adds 1-2 seconds per page on a
+    # 2-CPU pod with no quality benefit. Set `FILES_PARSER_PDF_DO_OCR=true`
+    # for scanned PDFs.
+    #
+    # `parser.pdf.do_table_structure` keeps Docling's default (`true`) so
+    # tabular content survives the markdown export. Disable only if you
+    # see table extraction errors on a particular corpus.
+    parser:
+      pdf:
+        do_ocr: ${FILES_PARSER_PDF_DO_OCR:-false}
+        do_table_structure: ${FILES_PARSER_PDF_DO_TABLE_STRUCTURE:-true}
+
     # -- Large-file chunking + retrieval (optional, per ADR-0002) ------------
     #
     # When enabled, files whose extracted text exceeds

--- a/templates/agent-loop/chart/templates/deployment.yaml
+++ b/templates/agent-loop/chart/templates/deployment.yaml
@@ -128,6 +128,19 @@ spec:
               value: "true"
             {{- end }}
             {{- end }}
+            {{- with .Values.files.parser }}
+            {{- if .pdf.doOcr }}
+            # Docling PDF pipeline knob — set "true" for scanned PDFs.
+            # Empty falls through to the agent.yaml default (do_ocr=false
+            # in 0.19.0+).
+            - name: FILES_PARSER_PDF_DO_OCR
+              value: {{ .pdf.doOcr | quote }}
+            {{- end }}
+            {{- if .pdf.doTableStructure }}
+            - name: FILES_PARSER_PDF_DO_TABLE_STRUCTURE
+              value: {{ .pdf.doTableStructure | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.files.chunking.enabled }}
             # Large-file chunking + retrieval (per ADR-0002). When enabled,
             # files >small_file_threshold_tokens are chunked, embedded via

--- a/templates/agent-loop/chart/values.yaml
+++ b/templates/agent-loop/chart/values.yaml
@@ -206,6 +206,17 @@ files:
     secretKey: ""
     prefix: ""                # optional key prefix within the bucket
     pathStyle: false
+  # Docling parser pipeline knobs (resolved against `agent.yaml`'s
+  # files.parser block). Only the PDF pipeline is exposed today; defer
+  # to agent.yaml defaults by leaving these empty.
+  #
+  # The agent.yaml default for `pdf.doOcr` is `false` — text-extractable
+  # PDFs parse in sub-second instead of multiple minutes per page. Set
+  # `pdf.doOcr: "true"` for scanned PDFs only.
+  parser:
+    pdf:
+      doOcr: ""                  # "" | "true" | "false"
+      doTableStructure: ""       # "" | "true" | "false"
   # Large-file chunking + retrieval (per ADR-0002). When enabled, files
   # whose extracted text exceeds small_file_threshold_tokens are split,
   # embedded via the configured OpenAI-compatible embedding endpoint,


### PR DESCRIPTION
Resolves #146.

## Summary

- `DocumentConverter()` was instantiated with no arguments, so Docling's `do_ocr=True` default ran RapidOCR on every PDF page even when the page had a selectable text layer. On a 2-CPU pod a text-extractable 80-page paper took several minutes to parse, blocking the 0.18.0 cluster smoke for PDF inputs.
- Adds `files.parser.pdf.{do_ocr,do_table_structure}` on `FilesConfig` and flips `do_ocr`'s default to `false`. Operators with scanned PDFs opt back in via `FILES_PARSER_PDF_DO_OCR=true` (or chart values).
- Surfaces the knobs in the agent-loop template (`agent.yaml` + Helm chart values + deployment env wiring) so a fresh scaffold inherits the new defaults end-to-end.

## Behaviour change

`do_ocr` default is now `false`. This is the headline UX fix — most modern PDFs ship a selectable text layer and OCR adds 1-2s per page on a 2-CPU pod with no quality benefit. Operators ingesting scanned PDFs must now set:

```yaml
# agent.yaml (or via FILES_PARSER_PDF_DO_OCR env)
server:
  files:
    parser:
      pdf:
        do_ocr: true
```

Backward-compat path: `DoclingParser()` with no `parser_config` still calls `DocumentConverter()` with no args (i.e. Docling's own defaults — including `do_ocr=True`). The framework default flip happens at the `agent.yaml` resolution layer, not at the `DoclingParser` constructor, so any direct callers of `DoclingParser()` keep their existing behaviour.

## Test plan

- [x] `ruff check` clean
- [x] `pytest packages/fipsagents` — 1181 passed / 12 skipped (was 1173/18 — 8 net new tests)
- [x] `pytest templates/agent-loop` — 345 passed (excluding pre-existing `test_example_agent.py` collection error tracked separately)
- [x] `helm lint templates/agent-loop/chart` clean
- [x] `helm template --set-string files.parser.pdf.doOcr=true ...` renders `FILES_PARSER_PDF_DO_OCR` env var on the agent container
- [x] `gitleaks detect` clean
- [ ] Cluster smoke: re-run the 7 MB / ~80-page PDF against `fipsagents-files-smoke` namespace once this lands. Expectation per #146: `parse_status: completed` in <60s on default 2-CPU pod.

## Verification (per issue)

- Unit: `tests/test_files_parser.py::TestPipelineOptions` parametrizes on `do_ocr × do_table_structure` and asserts the converter receives the expected `PdfPipelineOptions` via a fake-docling `sys.modules` injection (no real docling import needed).
- Default-flip test: `test_default_config_flips_do_ocr_off` pins the new framework default at the config layer.
- Backward-compat test: `test_no_config_keeps_no_args_constructor` confirms `DoclingParser()` still emits `DocumentConverter()` with no args when no config is provided.

## Out of scope

- Page-range / max-page knobs (separate feature).
- Native `HybridChunker` integration (NEXT_SESSION track B).
- Pre-baking Docling models into the runtime image (NEXT_SESSION track C).