### PR TITLE
chore(makefile): rename update-framework → update-fipsagents

### DIFF
--- a/templates/agent-loop/Makefile
+++ b/templates/agent-loop/Makefile
@@ -99,16 +99,21 @@ clean: ## Remove agent resources from OpenShift (make clean PROJECT=<name>)
 	@echo "Done."
 
 # ---------------------------------------------------------------------------
-# Framework vendoring
+# fipsagents vendoring
 # ---------------------------------------------------------------------------
 
 .PHONY: vendor
 vendor: ## Vendor fipsagents source into this project (replaces PyPI dependency)
 	fips-agents vendor
 
-.PHONY: update-framework
-update-framework: ## Update vendored fipsagents to latest upstream version
+.PHONY: update-fipsagents
+update-fipsagents: ## Update vendored fipsagents to latest upstream version
 	fips-agents vendor --update
+
+.PHONY: update-framework
+update-framework: ## Deprecated alias for update-fipsagents (will be removed in a future release)
+	@echo "warning: 'make update-framework' is deprecated; use 'make update-fipsagents' instead." >&2
+	@$(MAKE) update-fipsagents
 
 # ---------------------------------------------------------------------------
 # Help
@@ -121,7 +126,7 @@ help: ## Show this help message
 	@echo "=================================="
 	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Variables (override on CLI):"
 	@echo "  PROJECT     OpenShift project/namespace  (default: $(PROJECT))"

--- a/templates/agent-loop/README.md
+++ b/templates/agent-loop/README.md
@@ -196,7 +196,7 @@ make test-cov      # Run pytest with coverage
 make eval          # Run eval cases (mock LLM)
 make lint          # Run ruff linter
 make vendor        # Vendor fipsagents source (replaces PyPI dep)
-make update-framework  # Update vendored source from upstream
+make update-fipsagents # Update vendored source from upstream
 make help          # Show all targets
 ```
 


### PR DESCRIPTION
## Summary

- Renames the Makefile target `update-framework` to `update-fipsagents` so the name describes what's actually being updated (the `fipsagents` package).
- Keeps `update-framework` as a deprecated alias that prints a warning and delegates to `update-fipsagents`. Plan to remove it in a future release.
- Widens the `make help` column width from 14 → 18 so the longer target names render cleanly.
- Updates the in-template `README.md` reference to use the new name.

## Why

This is the agent-template companion to a broader cleanup of "framework" language across the fips-agents docs. fips-agents is a scaffolding toolkit (CLI + composable templates), not a framework — calling it that creates the wrong expectation about the runtime model. The target name was the last piece referring to "framework" without a concrete antecedent; aligning it with the package name (`fipsagents`) closes that loop.

## Test plan

- [x] `make help` renders both targets in the help table without column overflow
- [x] `make -n update-framework` shows the deprecation warning and delegates to `update-fipsagents`
- [x] `make -n update-fipsagents` invokes `fips-agents vendor --update`
- [ ] CI passes