### PR TITLE
server: Image input via OpenAI content blocks (closes #101)

### DIFF
--- a/packages/fipsagents/src/fipsagents/baseagent/agent.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/agent.py
@@ -347,8 +347,14 @@ class BaseAgent(abc.ABC):
 
     # -- Conversation state --------------------------------------------------
 
-    def add_message(self, role: str, content: str) -> None:
-        """Append a message to the conversation history."""
+    def add_message(self, role: str, content: str | list[dict[str, Any]]) -> None:
+        """Append a message to the conversation history.
+
+        ``content`` accepts either a plain string or a list of OpenAI-shaped
+        content blocks (e.g. ``{"type": "text", "text": ...}`` /
+        ``{"type": "image_url", "image_url": {...}}``) so multimodal callers
+        can append image-bearing turns without going through the HTTP layer.
+        """
         self.messages.append({"role": role, "content": content})
 
     def get_messages(self) -> list[dict[str, Any]]:

--- a/packages/fipsagents/src/fipsagents/baseagent/agent.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/agent.py
@@ -1162,7 +1162,19 @@ class BaseAgent(abc.ABC):
             if user_msg is None:
                 return
 
-            query = user_msg.get("content", "") or ""
+            # ``content`` may be a plain string or, for multimodal turns,
+            # a list of OpenAI-shaped content blocks. Build the search
+            # query by joining text from text-typed blocks; image blocks
+            # contribute nothing to retrieval.
+            original_content = user_msg.get("content", "") or ""
+            if isinstance(original_content, list):
+                query = "\n".join(
+                    b.get("text", "")
+                    for b in original_content
+                    if isinstance(b, dict) and b.get("type") == "text"
+                )
+            else:
+                query = original_content
             tag = self.config.memory.injection_tag
             injection_mode = self.config.memory.injection_mode
 
@@ -1198,9 +1210,17 @@ class BaseAgent(abc.ABC):
                 joined = joined[:limit] + "\n\n… [truncated]"
 
             if injection_mode == "user_turn":
-                self.messages[user_msg_idx]["content"] = (
-                    query + f"\n\n<{tag}>\n{joined}\n</{tag}>"
-                )
+                if isinstance(original_content, list):
+                    # Append a new trailing text block so image-only
+                    # messages survive (concatenating onto an empty
+                    # string would drop the image references).
+                    self.messages[user_msg_idx]["content"] = list(original_content) + [
+                        {"type": "text", "text": f"<{tag}>\n{joined}\n</{tag}>"}
+                    ]
+                else:
+                    self.messages[user_msg_idx]["content"] = (
+                        original_content + f"\n\n<{tag}>\n{joined}\n</{tag}>"
+                    )
                 logger.debug(
                     "Deferred memory injected into user turn (%d chars, pattern=%r)",
                     len(joined), pattern,

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import random
 import re
@@ -1091,6 +1092,89 @@ class OpenAIChatServer:
                 })
         return messages
 
+    async def _resolve_image_file_ids(
+        self, messages: list[dict[str, Any]]
+    ) -> None:
+        """Rewrite ``file_id:<id>`` image URLs to inline ``data:`` URIs.
+
+        Walks user messages whose ``content`` is a list of OpenAI-shaped
+        content blocks; for each ``image_url`` block whose ``url`` matches
+        ``file_id:<id>``, fetches the bytes from the configured
+        :class:`BytesStore`, sniffs the MIME type, and rewrites the URL in
+        place to ``data:{mime};base64,{...}`` before the request reaches
+        the model.
+
+        Mutates *messages* in place. No-op when no list-content user
+        messages reference ``file_id:`` URLs. Raises HTTP 400 if a
+        referenced file is missing or its MIME type cannot be detected,
+        and 503 if the server has no BytesStore configured.
+        """
+        # Cheap pre-scan: avoid a 503 / lookup when no message references
+        # a file_id. Most requests do not.
+        has_ref = False
+        for msg in messages:
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") != "image_url":
+                    continue
+                url = (block.get("image_url") or {}).get("url", "")
+                if isinstance(url, str) and url.startswith("file_id:"):
+                    has_ref = True
+                    break
+            if has_ref:
+                break
+        if not has_ref:
+            return
+
+        if self._bytes_store is None:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "image_url references a file_id but no BytesStore is "
+                    "configured (server.files.enabled=false)"
+                ),
+            )
+
+        for msg in messages:
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") != "image_url":
+                    continue
+                image_url = block.get("image_url") or {}
+                url = image_url.get("url", "")
+                if not (isinstance(url, str) and url.startswith("file_id:")):
+                    continue
+                file_id = url[len("file_id:") :]
+                data = await self._bytes_store.get(file_id)
+                if data is None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"file_id {file_id} not found",
+                    )
+                mime = detect_mime(data)
+                if not mime:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"could not detect MIME type for file_id {file_id}; "
+                            "image_url requires a recognisable image format"
+                        ),
+                    )
+                encoded = base64.b64encode(data).decode("ascii")
+                image_url["url"] = f"data:{mime};base64,{encoded}"
+
     def _should_trace(self) -> bool:
         """Decide whether to trace this request based on sampling rate."""
         if self._trace_store is None or self._agent is None:
@@ -1169,6 +1253,15 @@ class OpenAIChatServer:
                     content = msg.get("content")
                     if isinstance(content, str):
                         last_user = content
+                    elif isinstance(content, list):
+                        # Multimodal turn: join text from text-typed
+                        # blocks. Image blocks contribute nothing to
+                        # chunk retrieval.
+                        last_user = "\n".join(
+                            b.get("text", "")
+                            for b in content
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        )
                     break
             file_msgs = await self._resolve_file_attachments(
                 req.file_ids, last_user_message=last_user,
@@ -1182,6 +1275,12 @@ class OpenAIChatServer:
                     incoming = incoming[:-1] + file_msgs + incoming[-1:]
                 else:
                     incoming = file_msgs + incoming
+
+        # Multimodal: resolve any ``file_id:<id>`` image URLs to inline
+        # ``data:`` URIs. Runs after file_ids extraction so the existing
+        # text-RAG path is unaffected, and the rewrite is the last
+        # mutation of the message list before the model call.
+        await self._resolve_image_file_ids(incoming)
 
         # Trace ID: always generated so clients can correlate this
         # completion with feedback/observability data, even when tracing

--- a/packages/fipsagents/src/fipsagents/server/models.py
+++ b/packages/fipsagents/src/fipsagents/server/models.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import re
 import time
 import uuid
-from typing import Any
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
 from fipsagents.baseagent.events import StreamMetrics
-
 
 # Session ID format: 1-128 alphanumeric characters, hyphens, or underscores.
 _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
@@ -37,9 +36,39 @@ class CreateSessionRequest(BaseModel):
         return v
 
 
+class TextBlock(BaseModel):
+    """OpenAI-shaped text content block."""
+
+    type: Literal["text"]
+    text: str
+
+
+class ImageUrl(BaseModel):
+    """Inner ``image_url`` payload for :class:`ImageUrlBlock`.
+
+    ``url`` accepts a remote ``https://`` URL, an inline ``data:`` URI, or
+    the internal ``file_id:<id>`` scheme that the server resolves against
+    its :class:`~fipsagents.server.bytes_store.BytesStore` before
+    forwarding the request to the model.
+    """
+
+    url: str
+    detail: Literal["auto", "low", "high"] | None = None
+
+
+class ImageUrlBlock(BaseModel):
+    """OpenAI-shaped image content block."""
+
+    type: Literal["image_url"]
+    image_url: ImageUrl
+
+
+ContentBlock = Annotated[TextBlock | ImageUrlBlock, Field(discriminator="type")]
+
+
 class ChatMessage(BaseModel):
     role: str
-    content: str | None = None
+    content: str | list[ContentBlock] | None = None
     tool_calls: list[dict[str, Any]] | None = None
     tool_call_id: str | None = None
 
@@ -141,12 +170,19 @@ class UpdateFeedbackRequest(BaseModel):
 
 
 def _messages_to_dicts(messages: list[ChatMessage]) -> list[dict[str, Any]]:
-    """Convert incoming Pydantic messages back to OpenAI-shaped dicts."""
+    """Convert incoming Pydantic messages back to OpenAI-shaped dicts.
+
+    Multimodal content (a list of :class:`TextBlock` / :class:`ImageUrlBlock`)
+    is dumped block-by-block so the OpenAI SDK receives plain dicts.
+    """
     out: list[dict[str, Any]] = []
     for m in messages:
         d: dict[str, Any] = {"role": m.role}
         if m.content is not None:
-            d["content"] = m.content
+            if isinstance(m.content, list):
+                d["content"] = [b.model_dump() for b in m.content]
+            else:
+                d["content"] = m.content
         if m.tool_calls is not None:
             d["tool_calls"] = m.tool_calls
         if m.tool_call_id is not None:
@@ -167,8 +203,13 @@ def _extract_overrides(req: ChatCompletionRequest) -> dict[str, Any]:
 
     # Standard OpenAI parameters.
     for key in (
-        "temperature", "max_tokens", "top_p", "frequency_penalty",
-        "presence_penalty", "logprobs", "top_logprobs",
+        "temperature",
+        "max_tokens",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
     ):
         val = getattr(req, key, None)
         if val is not None:

--- a/packages/fipsagents/tests/test_deferred_memory.py
+++ b/packages/fipsagents/tests/test_deferred_memory.py
@@ -831,3 +831,120 @@ async def test_build_memory_prefix_respects_config_loading_pattern() -> None:
     assert len(mem.search_calls) == 0, (
         "build_memory_prefix() must not call search() when pattern is deferred"
     )
+
+
+# ---------------------------------------------------------------------------
+# Multimodal user_turn injection (#101) — content as a list of blocks
+# ---------------------------------------------------------------------------
+
+
+def _seeded_messages_with_content_blocks() -> list[dict[str, Any]]:
+    """User turn with mixed text + image content blocks."""
+    return [
+        {"role": "system", "content": "You are a test agent."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is the weather?"},
+                {"type": "image_url", "image_url": {"url": "file_id:file_abc"}},
+            ],
+        },
+    ]
+
+
+def _seeded_messages_image_only() -> list[dict[str, Any]]:
+    """User turn with only image content (no text block)."""
+    return [
+        {"role": "system", "content": "You are a test agent."},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "file_id:file_xyz"}},
+            ],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_user_turn_appends_text_block_when_content_is_list() -> None:
+    """For list content, memory is appended as a new trailing text block."""
+    mem = FakeMemoryHubClient(
+        [{"id": "a", "content": "Mixed-content memory"}],
+        project_config=_FakeProjectConfig(pattern="lazy"),
+    )
+    agent = _make_agent(memory=mem, injection_mode="user_turn")
+    agent.messages = _seeded_messages_with_content_blocks()
+
+    await agent._inject_deferred_memory()
+
+    user_content = agent.messages[1]["content"]
+    assert isinstance(user_content, list), (
+        f"List content must remain list-typed; got {type(user_content).__name__}"
+    )
+    # Original blocks preserved, new text block appended.
+    assert len(user_content) == 3
+    assert user_content[0] == {"type": "text", "text": "What is the weather?"}
+    assert user_content[1]["type"] == "image_url"
+    assert user_content[2]["type"] == "text"
+    assert "<user_memories>" in user_content[2]["text"]
+    assert "Mixed-content memory" in user_content[2]["text"]
+    assert "</user_memories>" in user_content[2]["text"]
+
+
+@pytest.mark.asyncio
+async def test_user_turn_search_query_built_from_text_blocks_only() -> None:
+    """Search query joins only text-typed blocks; image blocks contribute nothing."""
+    mem = FakeMemoryHubClient(
+        [{"id": "a", "content": "irrelevant"}],
+        project_config=_FakeProjectConfig(pattern="lazy"),
+    )
+    agent = _make_agent(memory=mem, injection_mode="user_turn")
+    agent.messages = _seeded_messages_with_content_blocks()
+
+    await agent._inject_deferred_memory()
+
+    assert len(mem.search_calls) == 1
+    query, _ = mem.search_calls[0]
+    assert query == "What is the weather?"
+
+
+@pytest.mark.asyncio
+async def test_user_turn_image_only_message_appends_text_block() -> None:
+    """Image-only message survives memory injection; new text block holds the tag."""
+    mem = FakeMemoryHubClient(
+        [{"id": "a", "content": "Image context"}],
+        project_config=_FakeProjectConfig(pattern="lazy"),
+    )
+    agent = _make_agent(memory=mem, injection_mode="user_turn")
+    agent.messages = _seeded_messages_image_only()
+
+    await agent._inject_deferred_memory()
+
+    user_content = agent.messages[1]["content"]
+    assert isinstance(user_content, list)
+    # The original image block is preserved; the new text block is appended.
+    assert len(user_content) == 2
+    assert user_content[0]["type"] == "image_url"
+    assert user_content[0]["image_url"]["url"] == "file_id:file_xyz"
+    assert user_content[1]["type"] == "text"
+    assert "<user_memories>" in user_content[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_user_turn_string_content_path_unchanged() -> None:
+    """Regression guard: string-content path still uses string concatenation."""
+    mem = FakeMemoryHubClient(
+        [{"id": "a", "content": "String memory"}],
+        project_config=_FakeProjectConfig(pattern="lazy"),
+    )
+    agent = _make_agent(memory=mem, injection_mode="user_turn")
+    agent.messages = _seeded_messages()
+
+    await agent._inject_deferred_memory()
+
+    user_content = agent.messages[1]["content"]
+    assert isinstance(user_content, str), (
+        f"String content must remain str-typed; got {type(user_content).__name__}"
+    )
+    assert user_content.startswith("What is the weather?")
+    assert "<user_memories>" in user_content

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -800,6 +800,138 @@ def test_messages_to_dicts_dumps_content_blocks_to_plain_dicts():
 
 
 # ---------------------------------------------------------------------------
+# _resolve_image_file_ids — file_id:<id> URL rewrite (#101)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBytesStore:
+    """Minimal BytesStore stub that returns canned payloads keyed by file_id."""
+
+    def __init__(self, payloads: dict[str, bytes]) -> None:
+        self._payloads = payloads
+        self.gets: list[str] = []
+
+    async def get(self, file_id: str) -> bytes | None:
+        self.gets.append(file_id)
+        return self._payloads.get(file_id)
+
+
+# 1×1 transparent PNG — small enough for inline test payloads, libmagic
+# recognises the PNG signature reliably.
+_PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c63000100000005000100200d0a2db40000000049"
+    "454e44ae426082"
+)
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_file_ids_rewrites_file_id_to_data_uri():
+    """file_id:<id> URLs become inline data: URIs after resolution."""
+    server = _build_server()
+    server._bytes_store = _FakeBytesStore({"file_abc": _PNG_BYTES})
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this"},
+                {"type": "image_url", "image_url": {"url": "file_id:file_abc"}},
+            ],
+        }
+    ]
+    await server._resolve_image_file_ids(messages)
+
+    rewritten = messages[0]["content"][1]["image_url"]["url"]
+    assert rewritten.startswith("data:image/png;base64,")
+    # Verify the BytesStore was actually consulted.
+    assert server._bytes_store.gets == ["file_abc"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_file_ids_noop_for_string_content():
+    """String-content user messages are untouched."""
+    server = _build_server()
+    server._bytes_store = _FakeBytesStore({})
+
+    messages = [{"role": "user", "content": "hello, no images here"}]
+    await server._resolve_image_file_ids(messages)
+
+    assert messages[0]["content"] == "hello, no images here"
+    # No lookup performed — pre-scan should short-circuit.
+    assert server._bytes_store.gets == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_file_ids_noop_for_remote_urls():
+    """Remote https URLs and inline data: URIs pass through unchanged."""
+    server = _build_server()
+    server._bytes_store = _FakeBytesStore({})
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/cat.jpg"},
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                },
+            ],
+        }
+    ]
+    await server._resolve_image_file_ids(messages)
+
+    urls = [b["image_url"]["url"] for b in messages[0]["content"]]
+    assert urls == [
+        "https://example.com/cat.jpg",
+        "data:image/png;base64,iVBORw0KGgo=",
+    ]
+    assert server._bytes_store.gets == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_file_ids_unknown_id_raises_400():
+    server = _build_server()
+    server._bytes_store = _FakeBytesStore({})
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "file_id:missing"}},
+            ],
+        }
+    ]
+    with pytest.raises(fastapi.HTTPException) as ei:
+        await server._resolve_image_file_ids(messages)
+    assert ei.value.status_code == 400
+    assert "missing" in ei.value.detail
+
+
+@pytest.mark.asyncio
+async def test_resolve_image_file_ids_no_bytes_store_raises_503():
+    """When files are disabled, a file_id reference must surface a 503."""
+    server = _build_server()
+    server._bytes_store = None
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "file_id:abc"}},
+            ],
+        }
+    ]
+    with pytest.raises(fastapi.HTTPException) as ei:
+        await server._resolve_image_file_ids(messages)
+    assert ei.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
 # /v1/agent-info
 # ---------------------------------------------------------------------------
 

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -28,7 +28,6 @@ from fipsagents.baseagent.events import (  # noqa: E402
 from fipsagents.baseagent.tools import ToolRegistry  # noqa: E402
 from fipsagents.server import OpenAIChatServer  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Stub agent helpers
 # ---------------------------------------------------------------------------
@@ -45,13 +44,16 @@ class _StubAgent(BaseAgent):
     def __init__(self, events=None, *, model_name: str = "stub-model", **kwargs):
         # Bypass BaseAgent.__init__ — we own everything the server touches.
         from fipsagents.baseagent.config import BudgetConfig, PricingConfig
+
         self._events = events or []
         self._system_prompt: str = ""
         self.messages: list[dict] = []
         self.tools = ToolRegistry()
         self.config = types.SimpleNamespace(
             model=types.SimpleNamespace(
-                name=model_name, temperature=0.7, max_tokens=4096,
+                name=model_name,
+                temperature=0.7,
+                max_tokens=4096,
             ),
             memory=types.SimpleNamespace(
                 injection_mode="prefix",
@@ -148,9 +150,7 @@ class _StubAgent(BaseAgent):
     async def shutdown(self) -> None:
         pass
 
-    async def astep_stream(
-        self, *, max_iterations: int = 10
-    ) -> AsyncIterator:
+    async def astep_stream(self, *, max_iterations: int = 10) -> AsyncIterator:
         for ev in self._events:
             yield ev
 
@@ -165,6 +165,7 @@ class _StubAgent(BaseAgent):
     # must be defined to satisfy the ABC.
     async def step(self):  # type: ignore[override]
         from fipsagents.baseagent import StepResult
+
         return StepResult.done()
 
 
@@ -189,7 +190,7 @@ def _parse_sse_body(body: str) -> list[dict | str]:
     for line in body.splitlines():
         if not line.startswith("data: "):
             continue
-        payload = line[len("data: "):]
+        payload = line[len("data: ") :]
         if payload == "[DONE]":
             frames.append("[DONE]")
         else:
@@ -343,14 +344,15 @@ def test_streaming_chat_completions_emits_sse_frames():
     assert _delta(frames[0]) == {"role": "assistant"}
 
     # At least one content chunk.
-    content_chunks = [f for f in frames if isinstance(f, dict) and "content" in _delta(f)]
+    content_chunks = [
+        f for f in frames if isinstance(f, dict) and "content" in _delta(f)
+    ]
     assert len(content_chunks) >= 1
     assert content_chunks[0]["choices"][0]["delta"]["content"] == "hi"
 
     # A finish_reason == "stop" chunk exists.
     stop_chunks = [
-        f for f in frames
-        if isinstance(f, dict) and _finish_reason(f) == "stop"
+        f for f in frames if isinstance(f, dict) and _finish_reason(f) == "stop"
     ]
     assert len(stop_chunks) == 1
 
@@ -390,7 +392,9 @@ def test_streaming_response_ends_with_usage_chunk_then_done():
 
 def test_streaming_tool_call_events_pass_through():
     events = [
-        ToolCallDelta(index=0, call_id="call_abc", name="search", arguments_delta='{"q":"x"}'),
+        ToolCallDelta(
+            index=0, call_id="call_abc", name="search", arguments_delta='{"q":"x"}'
+        ),
         ToolResultEvent(call_id="call_abc", name="search", content="the result"),
         ContentDelta(content="found it"),
         StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
@@ -408,10 +412,7 @@ def test_streaming_tool_call_events_pass_through():
     frames = _parse_sse_body(resp.text)
 
     # tool_calls chunk
-    tc_chunks = [
-        f for f in frames
-        if isinstance(f, dict) and "tool_calls" in _delta(f)
-    ]
+    tc_chunks = [f for f in frames if isinstance(f, dict) and "tool_calls" in _delta(f)]
     assert len(tc_chunks) >= 1
     tc = _delta(tc_chunks[0])["tool_calls"][0]
     assert tc["id"] == "call_abc"
@@ -419,8 +420,7 @@ def test_streaming_tool_call_events_pass_through():
 
     # tool result chunk (role == "tool")
     tool_result_chunks = [
-        f for f in frames
-        if isinstance(f, dict) and _delta(f).get("role") == "tool"
+        f for f in frames if isinstance(f, dict) and _delta(f).get("role") == "tool"
     ]
     assert len(tool_result_chunks) == 1
     assert _delta(tool_result_chunks[0])["tool_call_id"] == "call_abc"
@@ -428,7 +428,8 @@ def test_streaming_tool_call_events_pass_through():
 
     # content chunk (exclude tool-role chunks which also carry "content")
     content_chunks = [
-        f for f in frames
+        f
+        for f in frames
         if isinstance(f, dict)
         and "content" in _delta(f)
         and _delta(f).get("role") != "tool"
@@ -447,23 +448,31 @@ def test_streaming_sequential_tool_calls_across_iterations():
     """
     events = [
         # -- First model iteration: tool call A --
-        ToolCallDelta(index=0, call_id="call_aaa", name="get_weather", arguments_delta='{"city":'),
+        ToolCallDelta(
+            index=0, call_id="call_aaa", name="get_weather", arguments_delta='{"city":'
+        ),
         ToolCallDelta(index=0, arguments_delta='"Miami"}'),
         ToolResultEvent(call_id="call_aaa", name="get_weather", content="75°F sunny"),
         # -- Second model iteration: tool call B (same index, new call_id) --
-        ToolCallDelta(index=0, call_id="call_bbb", name="get_weather", arguments_delta='{"city":'),
+        ToolCallDelta(
+            index=0, call_id="call_bbb", name="get_weather", arguments_delta='{"city":'
+        ),
         ToolCallDelta(index=0, arguments_delta='"Seattle"}'),
         ToolResultEvent(call_id="call_bbb", name="get_weather", content="58°F cloudy"),
         # -- Final content --
         ContentDelta(content="Miami is 75°F, Seattle is 58°F."),
-        StreamComplete(finish_reason="stop", metrics=StreamMetrics(model_calls=2, tool_calls=2)),
+        StreamComplete(
+            finish_reason="stop", metrics=StreamMetrics(model_calls=2, tool_calls=2)
+        ),
     ]
     server = _build_server(events)
     with TestClient(server.app) as client:
         resp = client.post(
             "/v1/chat/completions",
             json={
-                "messages": [{"role": "user", "content": "weather in Miami and Seattle"}],
+                "messages": [
+                    {"role": "user", "content": "weather in Miami and Seattle"}
+                ],
                 "stream": True,
             },
         )
@@ -482,9 +491,9 @@ def test_streaming_sequential_tool_calls_across_iterations():
                 tc_open_chunks.append(tc)
 
     # Both tool calls must have received opening chunks with id + name.
-    assert len(tc_open_chunks) == 2, (
-        f"Expected 2 tool-call opening chunks, got {len(tc_open_chunks)}: {tc_open_chunks}"
-    )
+    assert (
+        len(tc_open_chunks) == 2
+    ), f"Expected 2 tool-call opening chunks, got {len(tc_open_chunks)}: {tc_open_chunks}"
     assert tc_open_chunks[0]["id"] == "call_aaa"
     assert tc_open_chunks[0]["function"]["name"] == "get_weather"
     assert tc_open_chunks[1]["id"] == "call_bbb"
@@ -509,9 +518,9 @@ def test_model_field_in_request_overrides_config_model():
         )
     frames = _parse_sse_body(resp.text)
     json_frames = [f for f in frames if isinstance(f, dict)]
-    assert all(f["model"] == "custom-model" for f in json_frames), (
-        f"Expected all frames to use 'custom-model', got: {[f['model'] for f in json_frames]}"
-    )
+    assert all(
+        f["model"] == "custom-model" for f in json_frames
+    ), f"Expected all frames to use 'custom-model', got: {[f['model'] for f in json_frames]}"
 
 
 def test_per_request_lock_serializes_streams():
@@ -692,6 +701,105 @@ def test_chat_request_accepts_valid_session_id():
 
 
 # ---------------------------------------------------------------------------
+# Multimodal content blocks (#101)
+# ---------------------------------------------------------------------------
+
+
+def test_chat_message_accepts_text_only_content_blocks():
+    from fipsagents.server.models import ChatMessage
+
+    msg = ChatMessage.model_validate(
+        {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+    )
+    assert isinstance(msg.content, list)
+    assert msg.content[0].type == "text"
+    assert msg.content[0].text == "hello"
+
+
+def test_chat_message_accepts_image_only_content_blocks():
+    from fipsagents.server.models import ChatMessage
+
+    msg = ChatMessage.model_validate(
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "file_id:file_abc"}},
+            ],
+        }
+    )
+    assert isinstance(msg.content, list)
+    assert msg.content[0].type == "image_url"
+    assert msg.content[0].image_url.url == "file_id:file_abc"
+
+
+def test_chat_message_accepts_mixed_content_blocks():
+    from fipsagents.server.models import ChatMessage
+
+    msg = ChatMessage.model_validate(
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe this"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://example.com/cat.jpg",
+                        "detail": "high",
+                    },
+                },
+            ],
+        }
+    )
+    assert isinstance(msg.content, list)
+    assert len(msg.content) == 2
+    assert msg.content[1].image_url.detail == "high"
+
+
+def test_chat_message_rejects_unknown_content_block_type():
+    from pydantic import ValidationError
+
+    from fipsagents.server.models import ChatMessage
+
+    with pytest.raises(ValidationError):
+        ChatMessage.model_validate(
+            {
+                "role": "user",
+                "content": [{"type": "audio_url", "audio_url": {"url": "x"}}],
+            }
+        )
+
+
+def test_messages_to_dicts_preserves_string_content():
+    from fipsagents.server.models import ChatMessage, _messages_to_dicts
+
+    out = _messages_to_dicts([ChatMessage(role="user", content="hi")])
+    assert out == [{"role": "user", "content": "hi"}]
+
+
+def test_messages_to_dicts_dumps_content_blocks_to_plain_dicts():
+    from fipsagents.server.models import ChatMessage, _messages_to_dicts
+
+    msg = ChatMessage.model_validate(
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this"},
+                {"type": "image_url", "image_url": {"url": "file_id:file_xyz"}},
+            ],
+        }
+    )
+    out = _messages_to_dicts([msg])
+    assert out[0]["role"] == "user"
+    blocks = out[0]["content"]
+    assert isinstance(blocks, list)
+    # Each block must be a plain dict so the OpenAI SDK can serialise it.
+    assert all(isinstance(b, dict) for b in blocks)
+    assert blocks[0] == {"type": "text", "text": "what is this"}
+    assert blocks[1]["type"] == "image_url"
+    assert blocks[1]["image_url"]["url"] == "file_id:file_xyz"
+
+
+# ---------------------------------------------------------------------------
 # /v1/agent-info
 # ---------------------------------------------------------------------------
 
@@ -859,9 +967,7 @@ def test_streaming_response_includes_x_trace_id_header_and_chunk_field():
     assert _TRACE_ID_RE.match(header_trace_id)
 
     frames = _parse_sse_body(resp.text)
-    usage_chunks = [
-        f for f in frames if isinstance(f, dict) and f.get("choices") == []
-    ]
+    usage_chunks = [f for f in frames if isinstance(f, dict) and f.get("choices") == []]
     assert len(usage_chunks) == 1
     assert usage_chunks[0]["trace_id"] == header_trace_id
 
@@ -937,14 +1043,18 @@ def _build_server_with_sqlite_sessions(tmp_path, events, *, model_name="stub"):
 def test_cost_data_persisted_across_turns(tmp_path):
     """Two completions on the same session_id accumulate cumulative totals."""
     metrics = StreamMetrics(
-        prompt_tokens=10, completion_tokens=4, total_tokens=14,
+        prompt_tokens=10,
+        completion_tokens=4,
+        total_tokens=14,
     )
     events = [
         ContentDelta(content="ok"),
         StreamComplete(finish_reason="stop", metrics=metrics),
     ]
     server = _build_server_with_sqlite_sessions(
-        tmp_path, events, model_name="stub-model",
+        tmp_path,
+        events,
+        model_name="stub-model",
     )
     with TestClient(server.app) as client:
         # Pre-create the session so the first save's upsert finds it.
@@ -1020,7 +1130,8 @@ def test_cost_data_persist_failure_does_not_break_response(tmp_path):
 
     with TestClient(server.app) as client:
         resp = client.post(
-            "/v1/sessions", json={"session_id": "sess_boom"},
+            "/v1/sessions",
+            json={"session_id": "sess_boom"},
         )
         assert resp.status_code == 201
 
@@ -1079,18 +1190,23 @@ def test_cost_data_null_session_store_is_noop():
 def test_cost_data_persisted_across_streaming_turns(tmp_path):
     """The streaming path also accumulates per-turn token usage."""
     metrics = StreamMetrics(
-        prompt_tokens=7, completion_tokens=3, total_tokens=10,
+        prompt_tokens=7,
+        completion_tokens=3,
+        total_tokens=10,
     )
     events = [
         ContentDelta(content="hi"),
         StreamComplete(finish_reason="stop", metrics=metrics),
     ]
     server = _build_server_with_sqlite_sessions(
-        tmp_path, events, model_name="stream-stub",
+        tmp_path,
+        events,
+        model_name="stream-stub",
     )
     with TestClient(server.app) as client:
         resp = client.post(
-            "/v1/sessions", json={"session_id": "sess_stream"},
+            "/v1/sessions",
+            json={"session_id": "sess_stream"},
         )
         assert resp.status_code == 201
 
@@ -1129,7 +1245,8 @@ def test_cost_data_no_usage_no_persist(tmp_path):
 
     with TestClient(server.app) as client:
         resp = client.post(
-            "/v1/sessions", json={"session_id": "sess_nousage"},
+            "/v1/sessions",
+            json={"session_id": "sess_nousage"},
         )
         assert resp.status_code == 201
 
@@ -1172,7 +1289,8 @@ def test_cost_data_http_get_not_implemented_falls_back_to_delta(tmp_path):
 
     with TestClient(server.app) as client:
         resp = client.post(
-            "/v1/sessions", json={"session_id": "sess_http_like"},
+            "/v1/sessions",
+            json={"session_id": "sess_http_like"},
         )
         assert resp.status_code == 201
 
@@ -1249,7 +1367,10 @@ def test_session_usage_404_when_session_missing(tmp_path):
         StreamComplete(finish_reason="stop", metrics=StreamMetrics()),
     ]
     server = _build_server_with_pricing(
-        tmp_path, events, model_name="stub", pricing=PricingConfig(),
+        tmp_path,
+        events,
+        model_name="stub",
+        pricing=PricingConfig(),
     )
     with TestClient(server.app) as client:
         resp = client.get("/v1/sessions/sess_nope/usage")
@@ -1266,7 +1387,10 @@ def test_session_usage_zero_for_new_session(tmp_path):
     ]
     pricing = PricingConfig(default=PricingRate(input_per_1k=0.01))
     server = _build_server_with_pricing(
-        tmp_path, events, model_name="stub", pricing=pricing,
+        tmp_path,
+        events,
+        model_name="stub",
+        pricing=pricing,
     )
     with TestClient(server.app) as client:
         client.post("/v1/sessions", json={"session_id": "sess_empty"})
@@ -1288,7 +1412,9 @@ def test_session_usage_computes_cumulative_dollars(tmp_path):
     from fipsagents.baseagent.config import PricingConfig, PricingRate
 
     metrics = StreamMetrics(
-        prompt_tokens=1000, completion_tokens=500, total_tokens=1500,
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
     )
     events = [
         ContentDelta(content="ok"),
@@ -1298,12 +1424,16 @@ def test_session_usage_computes_cumulative_dollars(tmp_path):
         default=PricingRate(input_per_1k=0.001, output_per_1k=0.002),
         models={
             "billed-model": PricingRate(
-                input_per_1k=0.01, output_per_1k=0.02,
+                input_per_1k=0.01,
+                output_per_1k=0.02,
             ),
         },
     )
     server = _build_server_with_pricing(
-        tmp_path, events, model_name="billed-model", pricing=pricing,
+        tmp_path,
+        events,
+        model_name="billed-model",
+        pricing=pricing,
     )
     with TestClient(server.app) as client:
         client.post("/v1/sessions", json={"session_id": "sess_paid"})
@@ -1347,7 +1477,8 @@ def test_tenant_label_flows_from_x_tenant_header(tmp_path):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.config.server.metrics = types.SimpleNamespace(
-                enabled=True, token_label_mode="tenant",
+                enabled=True,
+                token_label_mode="tenant",
             )
 
     server = OpenAIChatServer(_A)
@@ -1366,7 +1497,7 @@ def test_tenant_label_flows_from_x_tenant_header(tmp_path):
 
     body = metrics_resp.text
     assert 'tenant_id="acme-corp"' in body
-    assert 'agent_tokens_total{' in body
+    assert "agent_tokens_total{" in body
 
 
 def test_tenant_label_defaults_when_header_absent(tmp_path):
@@ -1384,7 +1515,8 @@ def test_tenant_label_defaults_when_header_absent(tmp_path):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.config.server.metrics = types.SimpleNamespace(
-                enabled=True, token_label_mode="tenant",
+                enabled=True,
+                token_label_mode="tenant",
             )
 
     server = OpenAIChatServer(_A)
@@ -1423,7 +1555,10 @@ def test_session_usage_uses_cost_data_model_over_default(tmp_path):
         },
     )
     server = _build_server_with_pricing(
-        tmp_path, events, model_name="billed-model", pricing=pricing,
+        tmp_path,
+        events,
+        model_name="billed-model",
+        pricing=pricing,
     )
     with TestClient(server.app) as client:
         client.post("/v1/sessions", json={"session_id": "sess_route"})


### PR DESCRIPTION
## Summary

Adds multimodal (image) input via the OpenAI content-block shape. Builds
on the audit captured in `NEXT_SESSION.md`.

- **`ChatMessage.content`** widened to `str | list[ContentBlock] | None`
  with a Pydantic discriminated union over `TextBlock` / `ImageUrlBlock`.
  `_messages_to_dicts` dumps each block to a plain dict.
- **`BaseAgent.add_message`** widened to accept content blocks. Pure type
  widening; the body already handles both shapes.
- **Deferred memory `user_turn` injection** dual-pathed: search query is
  joined from text-typed blocks; the rewrite appends a *new trailing
  text block* when content is a list (survives image-only turns). The
  string-content path is unchanged.
- **New `OpenAIChatServer._resolve_image_file_ids`** rewrites
  `file_id:<id>` URLs to inline `data:{mime};base64,…` URIs using the
  configured `BytesStore` + libmagic MIME sniff. Runs *after* the
  existing `file_ids` text-injection block so the extracted-text RAG
  path is unaffected.
- The existing last-user extraction (used to seed chunk retrieval) now
  joins text-block text when content is a list, so image-bearing turns
  still flow through chunk RAG.

Additive and backward-compatible. Cuts as `fipsagents 0.20.0` once
ready; CLI side (`fips-agents-cli` #20 `add vision`) lands after this.

## Out of scope (intentional)

- Cluster smoke against Granite Vision 3.2-2B — next session.
- `gateway-template`, `ui-template`, `examples` companion PRs.
- Vision endpoint split — single multimodal endpoint by default.
- Image-aware token accounting — trust the model `usage` response.
- #102 voice / #103 video.

## Test plan

- [x] `pytest packages/fipsagents` — 1131 passed, 1 skipped (full suite,
      excluding integration).
- [x] `ruff check` clean on all touched files.
- [x] New unit tests:
  - 4 `ContentBlock` Pydantic round-trip cases (text-only, image-only,
    mixed, unknown-type rejection)
  - 2 `_messages_to_dicts` cases (string passthrough, list → plain dicts)
  - 5 `_resolve_image_file_ids` cases (rewrite to data URI,
    string-content noop, remote-URL/data-URI passthrough, unknown id →
    400, missing BytesStore → 503)
  - 4 deferred-memory list-content cases (mixed-content append, query
    built from text blocks only, image-only survival, str-path
    regression guard)
- [ ] Cluster smoke against Granite Vision 3.2-2B (separate PR).

Closes #101.