### PR TITLE
server: Omit unset image_url.detail from dict serialisation

### DIFF
--- a/packages/fipsagents/src/fipsagents/server/models.py
+++ b/packages/fipsagents/src/fipsagents/server/models.py
@@ -174,13 +174,18 @@ def _messages_to_dicts(messages: list[ChatMessage]) -> list[dict[str, Any]]:
 
     Multimodal content (a list of :class:`TextBlock` / :class:`ImageUrlBlock`)
     is dumped block-by-block so the OpenAI SDK receives plain dicts.
+    ``exclude_none=True`` so optional fields the caller omitted (notably
+    ``image_url.detail``) stay absent rather than being serialised as
+    explicit ``null`` — the OpenAI SDK's
+    ``ChatCompletionContentPartImageParam`` rejects ``null`` for
+    ``detail`` even though the field itself is optional.
     """
     out: list[dict[str, Any]] = []
     for m in messages:
         d: dict[str, Any] = {"role": m.role}
         if m.content is not None:
             if isinstance(m.content, list):
-                d["content"] = [b.model_dump() for b in m.content]
+                d["content"] = [b.model_dump(exclude_none=True) for b in m.content]
             else:
                 d["content"] = m.content
         if m.tool_calls is not None:

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -799,6 +799,46 @@ def test_messages_to_dicts_dumps_content_blocks_to_plain_dicts():
     assert blocks[1]["image_url"]["url"] == "file_id:file_xyz"
 
 
+def test_messages_to_dicts_omits_unset_image_url_detail():
+    """Regression: ``detail`` defaults to None on ImageUrl, but the OpenAI SDK
+    rejects ``"detail": null`` even though the field is optional. The dump
+    must omit the key entirely when the caller didn't set it."""
+    from fipsagents.server.models import ChatMessage, _messages_to_dicts
+
+    msg = ChatMessage.model_validate(
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "https://example.com/a.png"}},
+            ],
+        }
+    )
+    out = _messages_to_dicts([msg])
+    image_url = out[0]["content"][0]["image_url"]
+    assert "detail" not in image_url, (
+        f"detail must be omitted when unset; got {image_url!r}"
+    )
+
+
+def test_messages_to_dicts_preserves_set_image_url_detail():
+    """When the caller does pass ``detail``, it round-trips through the dump."""
+    from fipsagents.server.models import ChatMessage, _messages_to_dicts
+
+    msg = ChatMessage.model_validate(
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/a.png", "detail": "high"},
+                },
+            ],
+        }
+    )
+    out = _messages_to_dicts([msg])
+    assert out[0]["content"][0]["image_url"]["detail"] == "high"
+
+
 # ---------------------------------------------------------------------------
 # _resolve_image_file_ids — file_id:<id> URL rewrite (#101)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up bug fix to #151 (image input via content blocks), found during
cluster smoke against Granite Vision 3.2-2B.

When a caller sends an \`image_url\` block without \`detail\`,
\`ImageUrl.detail\` defaults to \`None\`. \`model_dump()\` then emits
\`\"detail\": null\` in the dict. The OpenAI SDK rejects this:

\`\`\`
ChatCompletionContentPartImageParam: image_url.detail
  Input should be 'auto', 'low' or 'high' [type=literal_error, input_value=None]
\`\`\`

The field is optional but the key cannot be \`null\` — it must be
absent or one of the literal values.

## Fix

One-line change in \`_messages_to_dicts\`:
\`b.model_dump(exclude_none=True)\`. The two new regression tests pin
both shapes (\`detail\` omitted on the way in stays absent on the way
out; \`detail\` set on the way in round-trips faithfully).

## Verified

- Full \`fipsagents\` suite: 1133 passed (was 1131; +2 new), 1 skipped.
- End-to-end smoke against \`granite-vision-3.2-2b\`: agent received a
  request with \`{\"type\": \"image_url\", \"image_url\": {\"url\":
  \"file_id:<id>\"}}\`, looked up bytes via SqliteFileStore, libmagic-
  sniffed PNG, base64-rewrote to a \`data:\` URI, forwarded to vLLM,
  model responded with a one-word answer about the image. 0.39s
  round-trip; \`prompt_tokens=1546\` confirms image tokenisation.

## Test plan

- [x] \`pytest\` clean
- [x] Cluster smoke against Granite Vision 3.2-2B passes after the patch
- [x] No regression on the original PR #151 tests