### PR TITLE
docs: Document image input for fipsagents 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to the `fipsagents` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.20.0] - 2026-05-04
+
+Image input via OpenAI content blocks. Closes [#101](https://github.com/fips-agents/agent-template/issues/101).
+
+### Added
+
+- **`ChatMessage.content` accepts a list of content blocks** ([#151](https://github.com/fips-agents/agent-template/pull/151)). New Pydantic discriminated union over `TextBlock` and `ImageUrlBlock` mirrors the OpenAI multimodal request shape. Plain-string content is unchanged — the union is additive.
+- **`file_id:<id>` URL scheme for `image_url`** ([#151](https://github.com/fips-agents/agent-template/pull/151)). New `OpenAIChatServer._resolve_image_file_ids` walks user messages, fetches bytes from the configured `BytesStore`, sniffs the MIME type via libmagic, and rewrites the URL in place to `data:{mime};base64,…` before forwarding to the model. Internal scheme — no URL-format coupling, greppable, distinct from the existing `file_ids` text-RAG path. Runs *after* `file_ids` resolution so the extracted-text path is untouched.
+- **`BaseAgent.add_message` widened to accept content blocks** ([#151](https://github.com/fips-agents/agent-template/pull/151)). `content: str | list[dict[str, Any]]` lets multimodal callers append image-bearing turns directly.
+
+### Changed
+
+- **Deferred memory `user_turn` injection is dual-pathed** ([#151](https://github.com/fips-agents/agent-template/pull/151)). With list content, the search query is built by joining text from text-typed blocks (image blocks contribute nothing to retrieval) and the rewrite appends a *new trailing text block* with the `<tag>…</tag>` payload — survives image-only messages where string concatenation would have dropped image references. The string-content path is unchanged.
+- **`_resolve_file_attachments` last-user extraction tolerates list content** ([#151](https://github.com/fips-agents/agent-template/pull/151)). The chunk-retrieval seed query is now derived from joined text-block text when the user turn is multimodal, so image-bearing turns still flow through the chunk RAG path for any accompanying `file_ids`.
+
+### Fixed
+
+- **Unset `image_url.detail` no longer serialises as `null`** ([#152](https://github.com/fips-agents/agent-template/pull/152)). `ImageUrl.detail` defaults to `None`; `model_dump()` was emitting `"detail": null`, which the OpenAI SDK's `ChatCompletionContentPartImageParam` rejects (the field is optional but the key cannot be `null`). One-line fix: `model_dump(exclude_none=True)` in `_messages_to_dicts`. Surfaced during cluster smoke against Granite Vision 3.2-2B and would have hit any caller who omitted `detail`.
+
+### Notes
+
+- **Backward-compatible.** Existing string-content callers see no behavior change. The HTTP server, session store, and trace collector all round-trip list-content messages without modification (sessions JSON-encode `list[dict]`; the OpenAI SDK accepts content blocks unchanged).
+- **Vision endpoint shape.** Single multimodal endpoint via the existing `model.endpoint` — no separate `model.vision_endpoint` split. Add the split when a real driver shows up that needs separate text/vision routing.
+- **Token accounting.** Image-aware token counting trusts the model's `usage` response; vLLM reports image-expanded prompt tokens (e.g. ~1500 prompt tokens for a small PNG against Granite Vision 3.2-2B).
+- **Cluster-smoked.** End-to-end against Granite Vision 3.2-2B on cluster-n7pd5: agent received `{"type": "image_url", "image_url": {"url": "file_id:<id>"}}`, BytesStore lookup + libmagic MIME sniff + base64 rewrite, model returned a one-word answer about the image in 0.39s.
+- **Out of scope this release** (intentional): voice ([#102](https://github.com/fips-agents/agent-template/issues/102)), video ([#103](https://github.com/fips-agents/agent-template/issues/103)), tool calling on the vision path (Granite Vision uses a different chat template; the `granite` tool-call parser does not apply cleanly).
+
 ## [0.19.0] - 2026-04-30
 
 Docling PDF pipeline knobs on `FilesConfig`. Closes [#146](https://github.com/fips-agents/agent-template/issues/146).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -526,7 +526,12 @@ For multi-agent deployments with MemoryHub, multiple agents can connect to the s
 
 ## File Uploads
 
-`POST /v1/files` accepts multipart uploads, persists each file via the configured `FileStore`, and lets subsequent `/v1/chat/completions` requests reference them by passing `file_ids: ["file_..."]`. The framework injects each file's content into the conversation before the LLM sees the user's prompt. Uploads are an opt-in feature — set `server.files.enabled: true` and install the `[files]` extra to pull in Docling (text extraction) and `python-magic` (content-based MIME sniffing).
+`POST /v1/files` accepts multipart uploads, persists each file via the configured `FileStore`, and exposes them to subsequent `/v1/chat/completions` requests via two distinct paths depending on what the caller wants the model to see:
+
+- **Extracted text** — pass `file_ids: ["file_..."]` on the request body. The framework reads each file's extracted text (Docling for PDFs, native UTF-8 for plain text) and injects it as a system message just before the user's turn, or runs chunked retrieval against pgvector when chunking is enabled (see ADR-0002).
+- **Image bytes** — reference `file_id:<id>` from an `image_url` content block on the user message (`{"type": "image_url", "image_url": {"url": "file_id:..."}}`). `OpenAIChatServer._resolve_image_file_ids` walks user messages, fetches bytes from the configured `BytesStore`, sniffs the MIME type via libmagic, and rewrites the URL in place to `data:{mime};base64,…` before forwarding to the model. The same upload can be referenced via `file_ids` (text) and via `file_id:` (image bytes) on different requests; they are independent paths and never overlap.
+
+Uploads are an opt-in feature — set `server.files.enabled: true` and install the `[files]` extra to pull in Docling (text extraction) and `python-magic` (content-based MIME sniffing).
 
 ### Storage layout (per ADR-0001)
 

--- a/packages/fipsagents/README.md
+++ b/packages/fipsagents/README.md
@@ -61,7 +61,8 @@ if __name__ == "__main__":
 - **Configuration** — YAML with `${VAR:-default}` env var substitution
 - **Pluggable memory** — memoryhub, markdown, sqlite, pgvector, llamastack, custom, or null. Budget presets (`small`/`medium`/`large`) auto-tune for model context size. Deferred loading, user-turn injection for small models, and per-turn recall patterns
 - **Protective patterns** — max iterations, exponential backoff, rate limiting
-- **HTTP server** — OpenAI-compatible `/v1/chat/completions` endpoint with streaming and extended sampling parameters (top_p, top_k, repetition_penalty, reasoning_effort)
+- **HTTP server** — OpenAI-compatible `/v1/chat/completions` endpoint with streaming, extended sampling parameters (top_p, top_k, repetition_penalty, reasoning_effort), and multimodal content blocks (text + `image_url`). Image bytes can be referenced inline as `data:` URIs, by URL, or by the internal `file_id:<id>` scheme — uploads via `POST /v1/files` are resolved server-side from the configured `BytesStore` before the model call
+- **File uploads** — `POST /v1/files` accepts multipart uploads, persists each file via the configured `FileStore`, and exposes them either as extracted-text context (pass `file_ids: [...]` on a chat completion) or as image bytes (reference `file_id:<id>` from an `image_url` content block). Opt-in via the `[files]` extra
 - **`run_tool_calls()`** — one-line tool dispatch loop for non-streaming agents
 - **Agent identity** — name, description, version exposed via `/v1/agent-info`
 


### PR DESCRIPTION
## Summary

Documentation prep for cutting \`fipsagents 0.20.0\`. Closes the docs
gap left after #151 (image input) and #152 (image_url.detail fix).

- \`CHANGELOG.md\` — 0.20.0 entry covering Added / Changed / Fixed /
  Notes (cluster-smoked, out-of-scope items called out).
- \`packages/fipsagents/README.md\` — HTTP server bullet expanded to
  mention multimodal content blocks and \`file_id:<id>\`; new bullet
  for File uploads describing both retrieval paths.
- \`docs/architecture.md\` — File uploads section now distinguishes
  the two paths: extracted text via \`file_ids\` vs image bytes via
  \`file_id:<id>\` in an \`image_url\` content block. Notes the same
  upload can be referenced via either, independently.

## Test plan

- [x] CHANGELOG renders cleanly (Keep-a-Changelog format)
- [x] README and architecture.md edits read consistently with the
      existing tone
- [x] No code changes — pure docs PR