### PR TITLE
baseagent: Add tools.enabled config + close astep_stream tool-emission gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the `fipsagents` package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Added
+
+- **`tools.enabled` toggle on `ToolsConfig`** ([#155](https://github.com/fips-agents/agent-template/pull/155)). New boolean field (default `True`) that suppresses LLM-visible tool emission for an entire agent.  Set `tools.enabled: false` in `agent.yaml` for vision-only / voice-only deployments where the upstream vLLM checkpoint is served without a tool-calling chat template and 400s on `tools=[...]`.  The agent still discovers and registers local tools (so subclasses can call them programmatically) — only the schemas sent to the model are suppressed.
+- **`include_tools` per-call override on `astep_stream`** ([#155](https://github.com/fips-agents/agent-template/pull/155)). New keyword-only parameter (`bool | None = None`) mirroring the existing `include_tools` flag on `call_model`.  Resolution rule: explicit kwarg wins, else honor `config.tools.enabled`, else default `True` (backward-compatible for stubs that bypass `setup()`).  Closes the gap where `call_model(include_tools=False)` had no effect on the streaming HTTP path because the server uses `astep_stream`, not `call_model`.
+
 ## [0.20.0] - 2026-05-04
 
 Image input via OpenAI content blocks. Closes [#101](https://github.com/fips-agents/agent-template/issues/101).

--- a/packages/fipsagents/src/fipsagents/baseagent/agent.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/agent.py
@@ -412,6 +412,7 @@ class BaseAgent(abc.ABC):
         self,
         *,
         max_iterations: int = 10,
+        include_tools: bool | None = None,
         **model_kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
         """Streaming agent loop. Yields typed ``StreamEvent`` values.
@@ -436,6 +437,14 @@ class BaseAgent(abc.ABC):
         This is source-agnostic: tools from MCP servers and local
         ``@tool`` functions flow through the same dispatch point, so
         streaming looks identical regardless of tool origin.
+
+        ``include_tools`` is a per-call override controlling whether
+        registered tool schemas are emitted to the upstream model.
+        ``None`` (the default) honors ``config.tools.enabled``;
+        ``True``/``False`` overrides the config for this call only.  Set
+        ``False`` for vLLM checkpoints that 400 on tool schemas
+        (vision-only, voice-only).  Mirrors the ``include_tools`` flag
+        on :meth:`call_model`.
         """
         self._require_llm()
 
@@ -461,9 +470,18 @@ class BaseAgent(abc.ABC):
 
         finish_reason = "stop"
 
+        # Resolve once per call: explicit kwarg wins, else honor config,
+        # else default True for backward compatibility when self.config
+        # has not been initialized (eg test stubs that bypass setup()).
+        if include_tools is None:
+            cfg = getattr(self, "config", None)
+            tools_active = cfg.tools.enabled if cfg is not None else True
+        else:
+            tools_active = include_tools
+
         for _ in range(max_iterations):
             metrics.model_calls += 1
-            schemas = self.get_tool_schemas()
+            schemas = self.get_tool_schemas() if tools_active else []
             tools_arg = schemas if schemas else None
 
             # Accumulators for this turn. Keyed by tool_call index since

--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -152,10 +152,19 @@ class McpServerConfig(BaseModel):
 
 
 class ToolsConfig(BaseModel):
-    """Settings for local tool discovery."""
+    """Settings for local tool discovery and LLM-visible tool emission.
+
+    ``enabled`` controls whether tool schemas are emitted to the upstream
+    model.  When ``False``, the agent still discovers and registers tools
+    (so subclasses can call them programmatically) but the streaming agent
+    loop sends ``tools=None`` to the model.  Useful for vision-only or
+    voice-only checkpoints served by vLLM that 400 when tool schemas are
+    present.
+    """
 
     local_dir: str = "./tools"
     visibility_default: Literal["agent_only", "llm_only", "both"] = "agent_only"
+    enabled: bool = True
 
 
 class PromptsConfig(BaseModel):

--- a/packages/fipsagents/tests/test_astep_stream_tools_gating.py
+++ b/packages/fipsagents/tests/test_astep_stream_tools_gating.py
@@ -1,0 +1,182 @@
+"""Tests for ``astep_stream``'s tool-emission gating.
+
+Covers the four-way matrix between ``config.tools.enabled`` and the
+per-call ``include_tools`` override:
+
+================================  ================  =====================
+config.tools.enabled              include_tools     ``tools=`` to LLM
+================================  ================  =====================
+True                              None (default)    list of schemas
+False                             None (default)    None
+any                               True              list of schemas
+any                               False             None
+================================  ================  =====================
+
+The test mocks ``LLMClient.call_model_stream_raw`` and inspects the
+``tools`` kwarg captured on each invocation.  The agent's other
+machinery (memory, tool registry, reasoning parser) is bypassed with a
+minimal stub so we exercise just the gating logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator
+from types import SimpleNamespace
+
+import pytest
+
+from fipsagents.baseagent import BaseAgent
+from fipsagents.baseagent.config import AgentConfig, ToolsConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+_FAKE_SCHEMA: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "echo",
+            "description": "Echo input.",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+            },
+        },
+    }
+]
+
+
+class _SpyLLM:
+    """Captures kwargs of ``call_model_stream_raw`` and yields one final
+    chunk so the loop terminates cleanly with ``finish_reason='stop'``."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def call_model_stream_raw(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        self.calls.append({"messages": messages, "tools": tools, "kwargs": kwargs})
+        # Single chunk: empty content delta + finish_reason=stop ends the
+        # loop on the first iteration with no tool calls to dispatch.
+        choice = SimpleNamespace(
+            delta=SimpleNamespace(
+                content=None,
+                reasoning_content=None,
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )
+        yield SimpleNamespace(choices=[choice], usage=None)
+
+
+class _StubAgent(BaseAgent):
+    """Minimal BaseAgent that bypasses ``setup()``.
+
+    The real ``astep_stream`` calls ``_require_llm``,
+    ``_inject_deferred_memory``, ``get_tool_schemas``, and reads
+    ``self._reasoning_parser`` / ``self.config``.  We provide just enough
+    state for those.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: AgentConfig | None,
+        schemas: list[dict[str, Any]],
+    ) -> None:
+        # Skip BaseAgent.__init__ entirely — it expects a config path or
+        # an AgentConfig and triggers full setup.  We assemble state by
+        # hand so tests stay focused on the gating logic.
+        self.llm = _SpyLLM()
+        self.config = config
+        self.messages: list[dict[str, Any]] = []
+        self._reasoning_parser = None
+        self._schemas = schemas
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:  # type: ignore[override]
+        return list(self._schemas)
+
+    async def _inject_deferred_memory(self) -> None:  # type: ignore[override]
+        return None
+
+
+def _config_with_tools_enabled(enabled: bool) -> AgentConfig:
+    return AgentConfig(tools=ToolsConfig(enabled=enabled))
+
+
+async def _drain(agent: _StubAgent, **kwargs: Any) -> None:
+    """Iterate ``astep_stream`` to completion.  Discards events."""
+    async for _ in agent.astep_stream(**kwargs):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config_enabled, include_tools, expect_schemas",
+    [
+        # config drives behavior when include_tools is unset
+        (True, None, True),
+        (False, None, False),
+        # explicit kwarg wins over config in either direction
+        (True, False, False),
+        (False, True, True),
+        (True, True, True),
+        (False, False, False),
+    ],
+)
+async def test_astep_stream_tools_gating(
+    config_enabled: bool,
+    include_tools: bool | None,
+    expect_schemas: bool,
+) -> None:
+    agent = _StubAgent(
+        config=_config_with_tools_enabled(config_enabled),
+        schemas=_FAKE_SCHEMA,
+    )
+
+    if include_tools is None:
+        await _drain(agent)
+    else:
+        await _drain(agent, include_tools=include_tools)
+
+    assert len(agent.llm.calls) == 1
+    tools_arg = agent.llm.calls[0]["tools"]
+    if expect_schemas:
+        assert tools_arg == _FAKE_SCHEMA
+    else:
+        assert tools_arg is None
+
+
+@pytest.mark.asyncio
+async def test_astep_stream_with_no_config_defaults_to_emitting_tools() -> None:
+    """If ``self.config`` is ``None`` (eg test stub or bare init), the
+    legacy behavior — emit registered schemas — is preserved for
+    backward compatibility."""
+    agent = _StubAgent(config=None, schemas=_FAKE_SCHEMA)
+    await _drain(agent)
+    assert agent.llm.calls[0]["tools"] == _FAKE_SCHEMA
+
+
+@pytest.mark.asyncio
+async def test_astep_stream_no_registered_tools_sends_none() -> None:
+    """Empty schema list always serialises to ``tools=None`` regardless
+    of the config switch — ``tools=[]`` would also be valid but the loop
+    normalises to None to avoid sending an empty array on the wire."""
+    agent = _StubAgent(
+        config=_config_with_tools_enabled(True),
+        schemas=[],
+    )
+    await _drain(agent)
+    assert agent.llm.calls[0]["tools"] is None

--- a/packages/fipsagents/tests/test_config.py
+++ b/packages/fipsagents/tests/test_config.py
@@ -250,6 +250,32 @@ class TestAgentConfigDefaults:
 
 
 # ---------------------------------------------------------------------------
+# ToolsConfig
+# ---------------------------------------------------------------------------
+
+
+class TestToolsConfig:
+    def test_enabled_defaults_to_true(self):
+        config = AgentConfig()
+        assert config.tools.enabled is True
+
+    def test_enabled_false_parses_from_yaml(self):
+        config = load_config_from_string(
+            "tools:\n  enabled: false\n",
+        )
+        assert config.tools.enabled is False
+        # Other defaults remain intact.
+        assert config.tools.local_dir == "./tools"
+
+    def test_enabled_true_parses_from_yaml(self):
+        config = load_config_from_string(
+            "tools:\n  enabled: true\n  local_dir: ./custom\n",
+        )
+        assert config.tools.enabled is True
+        assert config.tools.local_dir == "./custom"
+
+
+# ---------------------------------------------------------------------------
 # LLMConfig
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds a config-level switch (`tools.enabled`, default `true`) that controls whether `astep_stream` emits tool schemas to the upstream model, plus a per-call `include_tools` kwarg for symmetry with `call_model`. This unblocks vision-only / voice-only vLLM checkpoints that return 400 on `tools=[...]`.

Closes the existing gap where `call_model(include_tools=False)` had no effect on the streaming HTTP path (the server uses `astep_stream`, not `call_model`).

## Why

0.20.0's image smoke worked around this by shipping with an empty `tools/` directory so `get_tool_schemas()` returned nothing. Awkward for agents that legitimately have local tools but talk to a checkpoint that can't use them on a given turn — and a hard blocker for #102/#103 (voice/video) which will hit the same wall.

Per `NEXT_SESSION.md` the user picked the config-level switch as the simplest unblock, with the per-call kwarg added so the streaming API mirrors `call_model`.

## Behavior

`astep_stream` resolves a single `tools_active` decision per call:

1. Per-call `include_tools` kwarg wins (`True`/`False`)
2. Else honor `self.config.tools.enabled`
3. Else default `True` (backward compat for test stubs that bypass `setup()`)

When `tools_active` is `False`, `get_tool_schemas()` is skipped and the call goes out with `tools=None`. The agent still discovers and registers local tools — only the LLM-visible schemas are suppressed.

No changes to `server/app.py`: the HTTP path inherits the config because the gate lives inside `astep_stream` itself. No request-level override is added — can be plumbed later if a real use case appears.

## Commits

- `d8c020b` — `config: Add tools.enabled toggle to ToolsConfig` (prep, schema only, no behavior change)
- `7f4d1c2` — `baseagent: Gate astep_stream tool emission on config + per-call kwarg`

## Test plan

- [x] `pytest packages/fipsagents/tests --ignore=packages/fipsagents/tests/integration` — 1144 passed, 1 skipped
- [x] `ruff check` clean on the four touched files
- [x] New parametrized test covers the four-way matrix (config_enabled × include_tools) plus no-config and empty-schemas edge cases
- [ ] Live smoke deferred until a no-tool-calling vLLM endpoint is convenient (per NEXT_SESSION.md sequencing — voice/video work would naturally exercise this)

## Out of scope

- `fipsagents[files]` extras split (Fix B in `NEXT_SESSION.md`) — separate PR
- Per-request HTTP override for `include_tools` — config switch is sufficient for the vision-only / voice-only motivating cases