### PR TITLE
packaging: Split [files] extra into [files-image] and [files-text]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **`tools.enabled` toggle on `ToolsConfig`** ([#155](https://github.com/fips-agents/agent-template/pull/155)). New boolean field (default `True`) that suppresses LLM-visible tool emission for an entire agent.  Set `tools.enabled: false` in `agent.yaml` for vision-only / voice-only deployments where the upstream vLLM checkpoint is served without a tool-calling chat template and 400s on `tools=[...]`.  The agent still discovers and registers local tools (so subclasses can call them programmatically) — only the schemas sent to the model are suppressed.
 - **`include_tools` per-call override on `astep_stream`** ([#155](https://github.com/fips-agents/agent-template/pull/155)). New keyword-only parameter (`bool | None = None`) mirroring the existing `include_tools` flag on `call_model`.  Resolution rule: explicit kwarg wins, else honor `config.tools.enabled`, else default `True` (backward-compatible for stubs that bypass `setup()`).  Closes the gap where `call_model(include_tools=False)` had no effect on the streaming HTTP path because the server uses `astep_stream`, not `call_model`.
 
+### Changed
+
+- **`[files]` extra split into `[files-image]` and `[files-text]`** ([#156](https://github.com/fips-agents/agent-template/pull/156)). Image-only agents that only need libmagic-based MIME sniffing can now install `fipsagents[files-image]` (~few MB) instead of dragging in docling + torch + transformers (~500 MB) via the meta extra. `[files-text]` retains the heavy docling toolchain for PDF/DOCX/PPTX/XLSX parsing. `[files]` is preserved as a meta-extra equal to the union, so existing pins like `pip install fipsagents[files]` and the agent-loop template's dependency resolve identically. No code-path changes — the lazy docling import in `parser.py` already gracefully degrades to `parse_status="skipped"` when docling is absent, which is exactly what an image-only deployment now sees.
+
 ## [0.20.0] - 2026-05-04
 
 Image input via OpenAI content blocks. Closes [#101](https://github.com/fips-agents/agent-template/issues/101).

--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -65,16 +65,31 @@ platform-client = [
     # sibling fipsagents-platform service.
     "httpx",
 ]
-files = [
+files-image = [
+    # MIME sniffing only — for agents that handle images via /v1/files
+    # but never parse binary documents.  Tens of MB instead of the ~500 MB
+    # docling pulls in via torch + transformers.  Requires libmagic at
+    # the OS level (``brew install libmagic`` on macOS, ``dnf install
+    # file-libs`` on UBI/RHEL). Falls back gracefully when libmagic is
+    # absent: server logs a warning and uses the client-supplied type.
+    "python-magic>=0.4.27",
+]
+files-text = [
     # Document parsing for /v1/files uploads. Docling covers PDF, DOCX,
     # PPTX, XLSX, HTML, and images. Plaintext parsing is built-in and
     # works without docling; this extra adds binary-format support.
+    # Pulls torch + transformers transitively (~500 MB).
     "docling>=2.30",
-    # MIME sniffing — detect actual file content rather than trusting
-    # the client-supplied Content-Type header. Requires libmagic at the
-    # OS level (``brew install libmagic`` on macOS, ``dnf install
-    # file-libs`` on UBI/RHEL). Falls back gracefully when libmagic is
-    # absent: server logs a warning and uses the client-supplied type.
+    # python-magic is needed to sniff the MIME type before dispatching
+    # to docling, so it lives in this extra too.
+    "python-magic>=0.4.27",
+]
+files = [
+    # Meta-extra: the union of files-image and files-text, preserved for
+    # backward compatibility with anything pinning ``fipsagents[files]``.
+    # New deployments that only handle images should prefer
+    # ``fipsagents[files-image]`` to avoid the docling footprint.
+    "docling>=2.30",
     "python-magic>=0.4.27",
 ]
 s3 = [

--- a/packages/fipsagents/tests/test_pyproject_extras.py
+++ b/packages/fipsagents/tests/test_pyproject_extras.py
@@ -1,0 +1,102 @@
+"""Regression tests for the [files*] optional-dependency split.
+
+The ``[files]`` extra used to bundle docling + python-magic, dragging in
+~500 MB of torch + transformers even for image-only agents that just
+need libmagic-based MIME sniffing.  We split it into:
+
+- ``[files-image]`` — python-magic only
+- ``[files-text]`` — python-magic + docling (heavy)
+- ``[files]`` — meta-extra equal to the union, kept so callers pinning
+  ``fipsagents[files]`` keep working unchanged
+
+These tests assert the structure so a future refactor does not silently
+collapse them back together.  They read ``pyproject.toml`` from the
+package root rather than installed metadata so they exercise the source
+of truth.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover — package requires-python = ">=3.11"
+    import tomli as tomllib  # type: ignore[import-not-found]
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def extras() -> dict[str, list[str]]:
+    pyproject = (
+        Path(__file__).resolve().parents[1] / "pyproject.toml"
+    )
+    with pyproject.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["optional-dependencies"]
+
+
+def _names(deps: list[str]) -> set[str]:
+    """Strip version specifiers / extras markers and return the bare
+    distribution names so assertions don't depend on minor version
+    bumps."""
+    out: set[str] = set()
+    for spec in deps:
+        # "python-magic>=0.4.27" → "python-magic"
+        # "docling>=2.30" → "docling"
+        for sep in (">=", "<=", "==", "!=", "~=", ">", "<", "[", ";"):
+            spec = spec.split(sep, 1)[0]
+        out.add(spec.strip())
+    return out
+
+
+def test_files_image_extra_exists_with_only_python_magic(extras):
+    assert "files-image" in extras, "files-image extra was removed"
+    names = _names(extras["files-image"])
+    assert names == {"python-magic"}, (
+        f"files-image should contain only python-magic, got {names}. "
+        "Adding docling here defeats the purpose of the split."
+    )
+
+
+def test_files_text_extra_includes_docling(extras):
+    assert "files-text" in extras, "files-text extra was removed"
+    names = _names(extras["files-text"])
+    assert "docling" in names, (
+        f"files-text must include docling for binary parsing, got {names}"
+    )
+    assert "python-magic" in names, (
+        f"files-text must include python-magic so MIME sniffing works "
+        f"alongside docling parsing, got {names}"
+    )
+
+
+def test_files_meta_extra_is_union(extras):
+    """``[files]`` is the backward-compatibility meta-extra.  It must
+    pull in everything ``[files-image]`` and ``[files-text]`` do, so
+    existing ``pip install fipsagents[files]`` keeps resolving identically.
+    """
+    assert "files" in extras, "files meta-extra was removed"
+    files_names = _names(extras["files"])
+    image_names = _names(extras["files-image"])
+    text_names = _names(extras["files-text"])
+    union = image_names | text_names
+    assert union <= files_names, (
+        f"files meta-extra is missing entries from the union: "
+        f"missing={union - files_names}, files={files_names}"
+    )
+
+
+def test_files_image_does_not_drag_in_docling(extras):
+    """Defensive duplicate of the first assertion — explicit so the
+    intent ('image agents must not pull torch') is greppable."""
+    names = _names(extras["files-image"])
+    assert "docling" not in names
+    # And no docling-adjacent heavyweights either.
+    for heavy in ("torch", "transformers"):
+        assert heavy not in names, (
+            f"files-image leaked {heavy} — image-only agents should "
+            "stay lightweight"
+        )


### PR DESCRIPTION
## Summary

Splits the monolithic `fipsagents[files]` extra into a lightweight image variant and a heavy text variant, so vision-only agents stop pulling ~500 MB of docling + torch + transformers they never use.

- `[files-image]` → `python-magic` only (~few MB)
- `[files-text]` → `python-magic` + `docling` (heavy; both needed — sniff to dispatch, then parse)
- `[files]` → meta-extra equal to the union, preserved for backward compatibility

## Why

0.20.0's image rollout (#101) brought vision-only agents online, but they still drag in the full docling toolchain through `[files]` because that's the only extra that includes libmagic-based MIME sniffing. Cold start and image footprint pay a 500 MB tax for the convenience of one tiny dependency. As voice/video (#102/#103) follow the same single-modality pattern, this gets worse.

Per `NEXT_SESSION.md` (Fix B).

## Behavior

No code changes. `parser.py` already gracefully degrades to `parse_status="skipped"` when docling is absent — that's exactly what an image-only `[files-image]` install now produces. The lazy import was already designed for this; we just made the install plumbing match.

## Backward compatibility

- `pip install fipsagents[files]` resolves identically to before.
- `templates/agent-loop/pyproject.toml` references `fipsagents[files]` and continues to work unchanged.
- `fips-agents-cli`'s `add files` and `add vision` commands need no changes — they install `[files]` (the meta), and the meta still pulls in everything.

## Test plan

- [x] `pytest packages/fipsagents/tests --ignore=packages/fipsagents/tests/integration` — 1137 passed, 1 skipped
- [x] New `test_pyproject_extras.py` (4 tests) parses pyproject and asserts:
  - `[files-image]` contains only `python-magic` (no docling)
  - `[files-text]` contains both `docling` and `python-magic`
  - `[files]` is a superset of the union (backward-compat guarantee)
  - `[files-image]` does not leak `torch` or `transformers`
- [x] `ruff check` clean on the new test file
- [ ] Live verification: `pip install fipsagents[files-image]` in a fresh venv, confirm the image upload path works against `/v1/files` — deferred until UI/voice work picks this up.

## Out of scope

- Pre-baking docling models into the runtime image (~700 MB cold-start saving) — this gets more meaningful once `[files-text]` is the heavy variant. Tracked as a sidequest in `NEXT_SESSION.md`.
- CLI changes — explicitly avoided per the doc's recommendation to keep `[files]` as the meta-extra.