### PR TITLE
templates: Update test_memory after 0.21.1 stub-config short-circuit

### DIFF
--- a/templates/agent-loop/tests/test_memory.py
+++ b/templates/agent-loop/tests/test_memory.py
@@ -346,15 +346,19 @@ class TestCreateMemoryClient:
 
     @pytest.mark.asyncio
     async def test_empty_config_file(self, tmp_path: Path):
-        """An empty YAML file should not crash — just produce a client."""
+        """An empty YAML file is treated as 'memory not configured'.
+
+        Post-fipsagents-0.21.1: ``_create_memoryhub_client`` short-circuits
+        to ``NullMemoryClient`` when the parsed config has no ``server_url``
+        / ``url`` field, so the SDK constructor is never called.
+        """
         config_file = tmp_path / ".memoryhub.yaml"
         config_file.write_text("")
 
-        mock_sdk_instance = _make_sdk()
         mock_memoryhub = MagicMock()
-        mock_memoryhub.MemoryHubClient.return_value = mock_sdk_instance
 
         with patch.dict("sys.modules", {"memoryhub": mock_memoryhub}):
             client = await create_memory_client(config_file)
 
-        assert isinstance(client, MemoryClient)
+        assert isinstance(client, NullMemoryClient)
+        mock_memoryhub.MemoryHubClient.assert_not_called()


### PR DESCRIPTION
## Summary

Follow-up to #159 / fipsagents 0.21.1.

`templates/agent-loop/tests/test_memory.py::test_empty_config_file` asserted pre-0.21.1 behaviour — that an empty `.memoryhub.yaml` returns a `MemoryClient`. After the stub-config short-circuit landed in fipsagents 0.21.1, an empty config returns `NullMemoryClient` without calling the SDK constructor at all.

This test was caught during a session-close audit, not by CI (the template's tests aren't run in any CI workflow).

## Why this slipped through

`templates/agent-loop/tests/` ships drifted copies of framework tests. The corresponding `packages/fipsagents/tests/test_memory.py` was already updated in #159; this template-side copy was missed. Full reconciliation of the duplicated test suite (~3,500 LoC of drift) is tracked separately as a follow-up.

## Test plan

- [x] `cd templates/agent-loop && .venv/bin/pytest tests/test_memory.py` — 28 passed