### PR TITLE
Add .fips-template.yaml manifests for agent-loop and workflow

### DIFF
--- a/templates/agent-loop/.fips-template.yaml
+++ b/templates/agent-loop/.fips-template.yaml
@@ -1,0 +1,91 @@
+# fips-agents-cli template manifest.
+#
+# This file declares which paths in the agent-loop template are managed
+# by the template (and so should be offered as patches by `fips-agents
+# patch`) and which belong to the user. The CLI reads this file from
+# the comparison root after cloning, before computing drift in
+# `fips-agents patch check`.
+#
+# When this file is absent, malformed, or declares an unsupported
+# schema_version, the CLI falls back to its hardcoded category set
+# keyed by template.type. See:
+#   https://github.com/fips-agents/fips-agents-cli/issues/45
+
+schema_version: 1
+
+patch:
+  categories:
+
+    chart:
+      description: Helm chart templates
+      patterns:
+        - chart/templates/**/*
+        - chart/Chart.yaml
+      ask_before_patch: true
+
+    docs:
+      description: Documentation files
+      patterns:
+        - CLAUDE.md
+        - AGENTS.md
+        - docs/**/*
+      ask_before_patch: false
+
+    build:
+      description: Build and deployment files
+      patterns:
+        - Makefile
+        - Containerfile
+        - deploy.sh
+        - redeploy.sh
+        - .containerignore
+        - .gitignore
+      ask_before_patch: true
+
+    claude:
+      description: Claude Code slash commands and rules shipped with the template
+      patterns:
+        - .claude/commands/**/*
+        - .claude/rules/**/*
+      ask_before_patch: false
+
+    evals:
+      description: Evaluation harness (discovery, assertions, runner)
+      patterns:
+        - evals/__init__.py
+        - evals/assertions.py
+        - evals/discovery.py
+        - evals/mock_factory.py
+        - evals/run_evals.py
+        - evals/README.md
+      ask_before_patch: true
+
+  never_patch:
+    # User's agent implementation
+    - src/agent.py
+    # User's agent config (model, prompts, server settings)
+    - agent.yaml
+    # User's deploy values
+    - chart/values.yaml
+    # Vendored runtime — managed by `fips-agents vendor --update`
+    - src/fipsagents/**
+    # User-authored tools (target of `fips-agents add code-executor`)
+    - tools/**
+    # User-authored examples (target of `fips-agents add vision`)
+    - examples/**
+    # User-customized prompts / rules / skills
+    - prompts/**
+    - rules/**
+    - skills/**
+    # User-authored eval inputs
+    - evals/evals.yaml
+    - evals/fixtures/**
+    # Tests are user code
+    - tests/**/*.py
+    # Environment files
+    - .env*
+    # User-customized memory hub config
+    - .memoryhub.yaml
+    # User's README and pyproject
+    - README.md
+    - pyproject.toml

--- a/templates/workflow/.fips-template.yaml
+++ b/templates/workflow/.fips-template.yaml
@@ -1,0 +1,91 @@
+# fips-agents-cli template manifest.
+#
+# This file declares which paths in the workflow template are managed
+# by the template (and so should be offered as patches by `fips-agents
+# patch`) and which belong to the user. The CLI reads this file from
+# the comparison root after cloning, before computing drift in
+# `fips-agents patch check`.
+#
+# When this file is absent, malformed, or declares an unsupported
+# schema_version, the CLI falls back to its hardcoded category set
+# keyed by template.type. See:
+#   https://github.com/fips-agents/fips-agents-cli/issues/45
+
+schema_version: 1
+
+patch:
+  categories:
+
+    chart:
+      description: Helm chart templates
+      patterns:
+        - chart/templates/**/*
+        - chart/Chart.yaml
+      ask_before_patch: true
+
+    docs:
+      description: Documentation files
+      patterns:
+        - CLAUDE.md
+        - AGENTS.md
+        - docs/**/*
+      ask_before_patch: false
+
+    build:
+      description: Build and deployment files
+      patterns:
+        - Makefile
+        - Containerfile
+        - deploy.sh
+        - redeploy.sh
+        - .containerignore
+        - .gitignore
+      ask_before_patch: true
+
+    claude:
+      description: Claude Code slash commands and rules shipped with the template
+      patterns:
+        - .claude/commands/**/*
+        - .claude/rules/**/*
+      ask_before_patch: false
+
+    evals:
+      description: Evaluation harness (discovery, assertions, runner)
+      patterns:
+        - evals/__init__.py
+        - evals/assertions.py
+        - evals/discovery.py
+        - evals/mock_factory.py
+        - evals/run_evals.py
+        - evals/README.md
+      ask_before_patch: true
+
+  never_patch:
+    # User's workflow implementation
+    - src/agent.py
+    # User's workflow config
+    - agent.yaml
+    # User's deploy values
+    - chart/values.yaml
+    # Vendored runtime — managed by `fips-agents vendor --update`
+    - src/fipsagents/**
+    # User-authored tools (target of `fips-agents add code-executor`)
+    - tools/**
+    # User-authored examples (target of `fips-agents add vision`)
+    - examples/**
+    # User-customized prompts / rules / skills
+    - prompts/**
+    - rules/**
+    - skills/**
+    # User-authored eval inputs
+    - evals/evals.yaml
+    - evals/fixtures/**
+    # Tests are user code
+    - tests/**/*.py
+    # Environment files
+    - .env*
+    # User-customized memory hub config
+    - .memoryhub.yaml
+    # User's README and pyproject
+    - README.md
+    - pyproject.toml


### PR DESCRIPTION
Companion PR to fips-agents/fips-agents-cli#48 (the CLI loader). After both merge, drift in this template's files surfaces in \`fips-agents patch check\` without needing a CLI release — the manifest is the source of truth.

## What

Adds \`.fips-template.yaml\` at:
- \`templates/agent-loop/.fips-template.yaml\`
- \`templates/workflow/.fips-template.yaml\`

Both manifests declare \`schema_version: 1\` and a \`patch:\` block with five categories — \`chart\`, \`docs\`, \`build\`, \`claude\`, \`evals\` — plus a 16-entry \`never_patch\` list separating template-managed files from user-authored ones.

## What changes vs. the CLI's hardcoded fallback

The categories largely mirror the CLI's \`AGENT_FILE_CATEGORIES\` constants, with two intentional additions to \`build\`:

- \`.containerignore\` — both templates ship this; previously unpatchable.
- \`.gitignore\` — same.

Everything else matches the constants 1-to-1 (after fips-agents/fips-agents-cli#43 + #46 land).

## Compatibility

Older CLI installs that don't know about \`.fips-template.yaml\` will simply ignore the file — nothing breaks. The CLI loader (fips-agents/fips-agents-cli#48) falls back to its hardcoded categories when the manifest is absent, malformed, or uses an unknown \`schema_version\`. So this PR is safe to land before, after, or independently of the CLI PR stack.

## Test plan

- [x] Both manifests parse cleanly through \`fips_agents_cli.tools.patching._load_template_manifest\` and \`_categories_from_manifest\` (validated locally against the loader from PR #48).
- [x] No secrets detected by gitleaks.
- [ ] After CLI #48 merges and a release ships, scaffold a fresh agent project and confirm \`patch check\` reports \`.containerignore\` / \`.gitignore\` drift in \`build\` (which the constants miss).