### PR TITLE
docs: Responsibilities doc + subagent tool design

### DIFF
--- a/docs/responsibilities.md
+++ b/docs/responsibilities.md
@@ -1,0 +1,261 @@
+# Responsibilities and Non-Goals
+
+This document is for contributors. It describes what `agent-template`
+is, what it is not, and which adjacent layer owns what. Read it before
+proposing a feature — it will save you time.
+
+The boundaries below are deliberate. They are not permanent. If you
+have a concrete use case the current boundaries do not serve, open a
+discussion issue and make the case. The point of writing them down is
+so we can argue with them, not so we can hide behind them.
+
+## What this project is
+
+`agent-template` is a general-purpose harness for building production
+AI agents that run on Red Hat OpenShift. It scaffolds an immutable
+container image with code, tools, prompts, skills, and rules baked in,
+and ships it through a Helm chart that consumes platform services
+(inference, memory, identity, tracing) provided by adjacent layers.
+
+It is not a coding agent. It is not an IDE. It is not a chat
+application. It is not a multi-tenant control plane. It is one tier in
+a stack — the tier that runs the agent loop.
+
+## What each adjacent layer owns
+
+The fips-agents stack is intentionally layered. When you find yourself
+about to add a feature, ask whether the concern belongs here or in one
+of the layers below. If it belongs elsewhere, the right move is usually
+to wire `agent-template` to consume the existing service rather than
+to reimplement it.
+
+### OGX (rebrand of LlamaStack) — orchestration, safety, observability
+
+OGX owns:
+
+- Server-side orchestration via the Responses API (`/v1/responses`):
+  MCP tool dispatch, shield enforcement, the inference loop.
+- Shields and guardrails (Llama Guard, Prompt Guard, custom shields).
+  Registered in OGX `config.yaml`; agents reference them by ID.
+- Moderation (`/v1/moderations`) and structured safety logs.
+- OpenTelemetry trace emission for the orchestration it performs.
+- The model registry — vLLM, llm-d, and any other inference provider
+  is abstracted behind OGX from the agent's perspective.
+
+`agent-template` consumes OGX as an HTTP endpoint. We do not
+reimplement Llama Guard. We do not maintain our own shield registry.
+We do not orchestrate MCP server-side when OGX is present (platform
+mode delegates that to OGX). When platform mode is disabled, the
+framework orchestrates MCP client-side via FastMCP v3 — that path
+exists because not every deployment runs OGX, not because we want to
+duplicate OGX's capabilities.
+
+### kagenti — identity, RBAC, multi-tenant boundaries
+
+kagenti owns:
+
+- Identity (who is this caller?).
+- RBAC (what is this caller allowed to do?).
+- Multi-tenant isolation at the service-mesh level.
+- Per-tenant network policy and authn/authz.
+
+`agent-template` accepts identity. It does not manage it. The
+permission policy planned for this project (allow/deny/ask per tool
+call) is about *capability gating* — which tools the LLM may invoke,
+with which arguments, under which scope. It layers on top of the
+identity kagenti provides. It does not replace kagenti's RBAC.
+
+If you find yourself proposing a multi-tenant feature, the answer is
+almost always "kagenti owns this." The exceptions — per-session
+isolation of conversation history, per-tool permission scoping — are
+narrow and well-defined.
+
+### Memory backends — persistent agent memory
+
+The framework defines a `MemoryClientBase` ABC. Implementations:
+
+- `memoryhub` — MemoryHub backend (centralized, governed, contradiction-tracked).
+- `markdown` — file-based, Git-friendly, dev/edge.
+- `sqlite` — local persistence, single-file.
+- `pgvector` — Postgres + pgvector, vector search.
+- `llamastack` — delegate to OGX/LlamaStack memory.
+- `custom` — bring your own implementation.
+- `null` — no memory, zero overhead.
+
+We use the abstraction. We do not reinvent it. MemoryHub is one
+backend among many — when discussing memory features, phrase them
+generically against the ABC, not against MemoryHub specifically.
+Memory CRUD, contradiction tracking, scoping (user / project /
+organizational / enterprise) are properties of the backend, not of
+this project.
+
+### OpenShift — platform, builds, deployment, monitoring
+
+OpenShift owns:
+
+- The cluster, namespaces, and project boundaries.
+- Secret management (Secrets, ESO, Vault integration).
+- Network policy and service mesh.
+- Build pipelines (BuildConfig, Tekton).
+- Built-in monitoring (Prometheus, Grafana, Alertmanager).
+- Workspace lifecycle (a "workspace" in our world is an OpenShift
+  project — we do not need a parallel concept).
+
+`agent-template` deploys as a tenant of OpenShift. The Helm chart
+declares what the agent needs; OpenShift provides it. We do not
+manage cluster-level resources. We do not ship a control plane.
+
+### Inference layer — the model itself
+
+vLLM, llm-d, llama.cpp, Ollama, OpenAI-compatible cloud endpoints — these
+host the model. The framework speaks OpenAI-compatible HTTP via the
+async `openai` SDK. When the inference provider is not natively
+OpenAI-compatible, the LLM adapter sidecar at `packages/llm-adapter/`
+translates.
+
+We are an OpenAI-compatible client. We do not host models. We do not
+fine-tune. We do not benchmark inference performance. We do not
+distribute model weights.
+
+### Adjacent fips-agents components — the rest of the stack
+
+`agent-template` is one repo in a stack of cooperating components.
+Knowing what each one owns prevents adding things to the wrong place.
+
+- **`gateway-template`** — Go HTTP gateway. Sits between `ui-template`
+  and one or more agents. Handles authentication, rate limiting,
+  request shaping, multi-agent routing. Coding-agent-style features
+  that conflate UI and agent (slash-command parsing, transcript
+  rendering, command-history UX) belong here, not in BaseAgent.
+- **`ui-template`** — chat UI. Renders conversations, streams events,
+  handles user input. All rendering decisions live here. If you find
+  yourself thinking about colors, keybindings, or panel layouts, you
+  are in the wrong repo.
+- **`code-sandbox`** — sandboxed code execution as an MCP server. If
+  an agent needs to run code (Python, shell), it calls this MCP
+  server through the standard MCP transport. The sandbox owns the
+  isolation boundary, resource limits, and language runtimes.
+- **`mcp-server-template`** — scaffolding for new MCP servers. When
+  you want to expose a new capability set (FHIR tools, OData, runbook
+  search), the right move is usually a new MCP server here, not new
+  built-in tools in this repo.
+- **`fipsagents-platform`** — REST veneer over the `fipsagents.server`
+  ABCs for cross-agent shared state (sessions, traces, files,
+  metrics) when multiple agents need to share. Single-agent
+  deployments do not need it.
+- **`fips-agents-cli`** (`fips-agents` command) — the scaffolding CLI.
+  It clones this template, the workflow template, and others, then
+  customizes them for a specific agent. It does not ship runtime
+  code; it ships scaffolding.
+
+When proposing a feature, ask: does this belong in BaseAgent (the
+agent loop), in `fipsagents.server` (HTTP / persistence / observation),
+in the gateway (request shaping, multi-agent routing), in the UI
+(rendering), in an MCP server (a capability set), or in an extension
+(a domain-specific bundle of tools / prompts / skills)? Most "I want
+to add X" answers are not "X goes in BaseAgent."
+
+## Explicit non-goals
+
+The list below is what we have actively decided not to build into this
+project. Each item has a rationale; the rationale is the load-bearing
+part — if your situation invalidates it, that is a real argument, not
+just a preference clash.
+
+- **TUI, themes, custom keybindings, IDE/editor integration.** UI
+  decisions live in `ui-template`. This project ships HTTP servers
+  (OpenAI-compatible chat completions, plus a few adjacent endpoints).
+  How that gets rendered to a human is not our concern. Adding
+  terminal UI here would either fork into a competing UI surface or
+  duplicate work `ui-template` already does.
+- **Language Server Protocol integration, glob/grep/edit/apply_patch
+  coding tools, formatters, terminal/PTY emulators.** These are the
+  vocabulary of a coding agent. A general-purpose harness should not
+  ship them. They belong in a code-tools extension that downstream
+  projects opt into. Bundling them into the core would constrain
+  every non-coding agent (customer service, ops, healthcare,
+  document processing) with capabilities they neither want nor can
+  audit.
+- **Git shadow-repo snapshots for file-edit revert.** A coding-agent
+  feature that doesn't generalize. The general-purpose subset is
+  session fork and revert at the data layer (planned), which works
+  for any session regardless of whether it touched files.
+- **Cross-device session sync via event sourcing.** This drives
+  "phone-controls-IDE" use cases that are not the deployed-on-OpenShift
+  shape we target. It also imposes a substantial complexity tax
+  (event log, conflict resolution, replay semantics) for a benefit
+  that vanishes in a server-deployed agent.
+- **Public share-this-conversation URLs.** A compliance footgun in
+  regulated environments (healthcare, finance, regulated industrial).
+  Tenant-owned export — the operator can pull a session and share it
+  through tenant-controlled channels — is the right answer. Public
+  unauthenticated URLs are not.
+- **Workspaces, project registry, user dashboards, control plane.**
+  kagenti owns multi-tenant boundaries; OpenShift owns workspace
+  lifecycle. We do not need a parallel concept of "workspace" in
+  `agent-template`. If a feature needs the idea of "what is the
+  current project", it should derive that from kagenti's identity
+  context, not from a registry we maintain.
+- **Agent Client Protocol (ACP) or any IDE-driver protocol.** ACP is
+  designed for IDEs to drive coding agents. Our equivalent ecosystem
+  play is OpenAI-compatible HTTP — every gateway, UI, automation
+  tool, and notebook in the world speaks it. We are not adding a
+  second protocol to chase IDE integration that we are not the right
+  layer to provide.
+- **npm-style runtime plugin systems / pip-install-at-startup
+  extensibility.** Incompatible with the immutable-image model.
+  Extension points are ABC-based: pluggable memory backends,
+  pluggable session/trace stores, custom tool implementations
+  registered via `@tool`, custom node implementations registered via
+  `@node`. Anything dynamic enough to need runtime install belongs
+  in an MCP server, not in the agent's process.
+- **Multi-language agent loops (TypeScript, Go, Java BaseAgent
+  ports).** Python is the language of the agent. Other languages
+  consume it via OpenAI-compatible HTTP. Maintaining parallel
+  framework implementations across languages is a tax we are not
+  paying.
+
+## Domain-specific capabilities go in extensions
+
+A general-purpose template cannot be all things. Healthcare needs FHIR
+(patient / encounter / observation tools, terminology services,
+deidentification utilities). Industrial needs OData and OPC UA.
+Software engineering needs a code-tools extension (glob, scoped
+read/write, AST navigation, sandboxed execution). Retail needs
+catalog and inventory tools. Finance needs compliance helpers.
+
+None of these belong in the main template. They belong in extensions —
+domain-specific bundles that contribute tools, prompts, skills,
+optional memory backends, and configuration to an agent at scaffold
+time.
+
+The shape of the extension model is currently being designed. See the
+"template extensions / add-ons" architecture discussion issue for the
+open questions: layout (separate template repos, packaged
+distributions, submodules), discovery (declared in `agent.yaml`),
+surface (what an extension contributes), versioning, namespacing, and
+deployment.
+
+The point of getting extensions right early: every domain ends up
+needing the same shape. Without a first-class model, every team forks
+the template, copies the same five tools into it, and we end up with
+N divergent forks instead of N domain extensions composing on a
+shared core.
+
+## How to challenge a non-goal
+
+The boundaries above are explicit so you can argue with them. If you
+have a concrete use case the current scope does not serve:
+
+1. Open a discussion issue (label `enhancement`, mention the relevant
+   non-goal in the body).
+2. State the use case in plain language. Lead with the user, not the
+   feature.
+3. Explain why one of the adjacent layers (OGX, kagenti, gateway, UI,
+   an MCP server, an extension) cannot serve the need.
+4. Propose where in the stack the capability would live if added.
+
+The most persuasive arguments are concrete: a real downstream agent
+that hits a wall, a specific compliance requirement, a real-world
+integration that the current scope blocks. Hypotheticals carry less
+weight than scars.

--- a/planning/subagent-tool-design.md
+++ b/planning/subagent-tool-design.md
@@ -1,0 +1,488 @@
+# Subagent Tool Design (#165)
+
+## Problem
+
+A primary agent often needs to delegate part of a turn to a specialist
+agent and incorporate the result without restructuring the entire
+conversation as a workflow graph. The current options are unsatisfying:
+
+- **Workflow graph.** Powerful but heavyweight. Topology is static at
+  deploy time. Every delegation pair has to be a node-and-edge in the
+  graph, which is the wrong shape for ad-hoc, model-driven decisions
+  about *whether* to delegate.
+- **Hand-rolled HTTP call.** A tool that does `httpx.post` to another
+  agent's `/v1/chat/completions` works in the small, but skips the
+  framework's logging, tracing, cost attribution, identity propagation,
+  and permission enforcement. Every team that builds it ends up
+  reimplementing the same five concerns badly.
+
+The motivating use cases are deliberately non-coding:
+
+- **Customer service.** A general-purpose support agent delegates an
+  account lookup to a tenant-specific account agent that has the
+  customer's records and tools wired in.
+- **Operations.** A primary ops agent delegates runbook search to a
+  runbook-specialist agent whose MCP servers and prompts are tuned for
+  retrieval-and-summarise workflows.
+- **Data analysis.** An analyst agent delegates SQL synthesis to a
+  query-builder agent that has the schema baked into its prompt.
+- **Document processing.** A coordinator agent fans out per-file
+  analysis across N identical worker agents and aggregates results.
+
+Every one of these is a tool call in spirit: the primary agent forms an
+intent, names a target, passes a payload, gets back a structured
+result, and continues. Subagent-as-tool makes that pattern first-class.
+
+## Design principle
+
+**Composable delegation as a tool, not a workflow primitive.** The
+subagent tool sits at the tool plane — the same surface the LLM uses
+for any other capability. Discovery is config-driven (`subagents:` in
+`agent.yaml`), invocation is a normal tool call, and the result is a
+typed payload the LLM can branch on.
+
+This is intentionally orthogonal to the workflow graph. Workflows
+remain the right shape when topology is known up front, when the
+graph itself encodes business logic, or when nodes need to share
+typed state. Subagent-as-tool is the right shape when the primary
+agent decides *at runtime* whether to delegate, based on the user's
+intent and the model's judgement.
+
+The framework gives the tool everything it needs to be a good
+citizen: conversation isolation, cost roll-up, trace propagation,
+permission scoping, identity inheritance, depth bounds. The user
+writes one config block and gets all of that for free.
+
+## Subagent lifecycle
+
+```
+                Parent agent step
+                       │
+                       ▼
+        ┌────────────────────────────┐
+        │  LLM emits tool_call:      │
+        │  delegate_to_agent(...)    │
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │  Permission gate (#164)    │
+        │  scope check + ask flow    │
+        └────────────┬───────────────┘
+                     │ allow
+                     ▼
+        ┌────────────────────────────┐
+        │  Resolve subagent config   │
+        │  by `agent_name`           │
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │  Build subagent context:   │
+        │  - fresh messages list     │
+        │  - inherited identity      │
+        │  - scoped permissions      │
+        │  - injected trace headers  │
+        │  - depth + 1               │
+        └────────────┬───────────────┘
+                     │
+            ┌────────┴────────┐
+            ▼                 ▼
+       remote transport   inprocess transport
+       (HTTP, RemoteNode) (instantiate class)
+            │                 │
+            └────────┬────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │  Subagent runs its own     │
+        │  step loop (isolated)      │
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │  Build SubagentResult:     │
+        │  - final content           │
+        │  - tokens_used             │
+        │  - tool_calls_made         │
+        │  - cost_usd                │
+        │  - span_id                 │
+        └────────────┬───────────────┘
+                     │
+                     ▼
+        ┌────────────────────────────┐
+        │  Roll up into parent:      │
+        │  - BudgetEnforcer          │
+        │  - close OTEL child span   │
+        │  - structured log          │
+        └────────────┬───────────────┘
+                     │
+                     ▼
+            Parent agent continues
+```
+
+The subagent's intermediate messages are not visible to the parent.
+The parent sees one tool call, one tool result. The subagent's full
+trace is reconstructable from OTEL spans and structured logs but does
+not pollute the parent's conversation.
+
+## Architecture
+
+### Where this lives
+
+- **Stock tool.** A new file in the template's `tools/` directory:
+  `tools/delegate_to_agent.py`. Decorated with `@tool(visibility="both")`.
+  Auto-discovered by the existing tool registry on agent setup.
+- **Config.** A new top-level `subagents:` block in `agent.yaml`,
+  validated by a new `SubagentConfig` Pydantic model on `AgentConfig`.
+- **Transport adapters.** Two implementations under
+  `fipsagents.subagents`:
+  - `RemoteSubagentTransport` — wraps an `httpx.AsyncClient` and posts
+    to the target's `/v1/chat/completions`. Reuses
+    `propagation.inject_trace_context()`.
+  - `InProcessSubagentTransport` — instantiates a subagent class in
+    the same process. Used in tests and for tightly-coupled
+    compositions.
+- **Streaming events.** New `StreamEvent` variants:
+  - `SubagentInvoked(agent_name, task, span_id)` — emitted when the
+    delegation starts.
+  - `SubagentCompleted(agent_name, result, tokens_used)` — emitted
+    when the subagent returns.
+  - `SubagentFailed(agent_name, error)` — emitted on timeout or crash.
+  - `SubagentDelta(agent_name, delta)` — v2, emitted while the
+    subagent is streaming.
+
+### Reuse, do not reinvent
+
+- **Trace propagation.** `fipsagents.server.propagation` already
+  implements W3C Trace Context. The remote transport calls
+  `inject_trace_context()` before posting; the receiving agent
+  already calls `extract_trace_context()` on inbound requests.
+- **HTTP transport semantics.** `RemoteNode` in
+  `fipsagents.workflow` already shells out to a remote agent over
+  OpenAI-compatible HTTP. The subagent remote transport is a
+  generalisation — same wire shape, different invocation surface
+  (tool call vs. workflow node).
+- **Cost accounting.** `BudgetEnforcer` already tracks tokens and
+  cost. The subagent tool calls `BudgetEnforcer.record_subagent(
+  result.tokens_used, result.cost_usd)` on completion.
+- **Permission enforcement.** The permission policy (#164) runs in
+  `BaseAgent.handle_tool_call` before dispatch. The subagent tool
+  goes through the same gate as any other tool.
+
+## Configuration shape
+
+```yaml
+subagents:
+  - name: research_helper
+    description: \"Searches internal knowledge base and returns a synthesised brief.\"
+    when_to_use: \"Use when the user asks an open-ended policy question.\"
+    transport:
+      type: remote
+      url: ${RESEARCH_HELPER_URL:-http://research-helper:8080/v1}
+      timeout_seconds: 60
+    permission_scope: research-readonly
+    identity: inherit
+    max_depth: 3
+
+  - name: account_lookup
+    description: \"Looks up an account by ID and returns relevant fields.\"
+    when_to_use: \"Use when the user references an account by ID.\"
+    transport:
+      type: remote
+      url: ${ACCOUNT_LOOKUP_URL}
+      timeout_seconds: 15
+    permission_scope: account-read
+    identity:
+      service_account: account-reader  # explicit override
+    max_depth: 1
+```
+
+Field reference:
+
+- `name` — the identifier the LLM uses in the `agent_name` parameter
+  (or the suffix of the synthesised tool name if we go that route).
+- `description` — surfaced in the tool schema so the LLM knows what
+  this subagent does.
+- `when_to_use` — a hint baked into the tool's docstring/schema so
+  the LLM has guidance on selection.
+- `transport.type` — `remote` or `inprocess`.
+- `transport.url` — for remote, the OpenAI-compatible endpoint base.
+  Standard `${VAR:-default}` env-var substitution applies.
+- `transport.timeout_seconds` — per-call timeout; subagent failures
+  do not block the parent indefinitely.
+- `permission_scope` — references a named rule set in
+  `PermissionConfig.scopes` (#164). The subagent runs under
+  `min(parent_scope, this_scope)`.
+- `identity` — `inherit` (default; subagent runs as the caller) or
+  `service_account: <name>` (subagent runs as a fixed service
+  identity, useful when the subagent has its own kagenti-issued
+  credentials).
+- `max_depth` — cap on delegation chains. The framework tracks depth
+  in the trace context and rejects subagent calls that would exceed
+  the cap.
+
+## Permission propagation
+
+Permissions are the security-load-bearing part of this design. The
+rules:
+
+1. **The parent's permission scope is the upper bound.** A subagent
+   cannot invoke a tool the parent itself is not authorised to
+   invoke. The framework enforces this by intersecting the parent's
+   active rule set with the subagent's declared `permission_scope`.
+2. **Subagents declare what they need.** `permission_scope` on the
+   subagent config identifies a named rule set in the parent's
+   `PermissionConfig.scopes`. The framework rejects the call at
+   config-validation time if the named scope does not exist.
+3. **Identity inheritance defaults to the caller.** A subagent
+   invoked under `identity: inherit` carries the parent's
+   kagenti-issued identity in its outbound HTTP headers. The
+   subagent's own permission policy then layers on top — the
+   subagent decides what *its* identity is allowed to do, the parent
+   decides what the subagent invocation is allowed to do, and the
+   intersection wins.
+4. **Service-account override.** When a subagent has its own
+   credentials (e.g. an account-lookup agent with read-only DB
+   access), the parent specifies `identity: service_account: <name>`.
+   The framework looks up the service account from kagenti and
+   issues the call under that identity. This is the right shape for
+   subagents that need stronger isolation than the caller's identity
+   provides.
+5. **Depth-bounded.** A delegation chain (A → B → C → D) is bounded
+   by the `max_depth` of the *first* subagent in the chain. The
+   framework increments a depth counter in the trace baggage; the
+   receiving agent rejects calls that exceed the cap with a
+   structured error.
+
+There is no escalation path. A subagent cannot ask for capabilities
+the parent does not have. If a workflow needs more privilege at a
+deeper level, that is a deployment-topology decision (different
+service account at the chain root), not a runtime policy decision.
+
+## Cost & tracing
+
+### Cost roll-up
+
+Every `SubagentResult` includes `tokens_used` and `cost_usd`. The
+parent's `BudgetEnforcer` records these against the parent's session.
+The parent's per-step token cap, per-session token cap, and per-USD
+cost cap all apply. A single subagent that exceeds the parent's
+remaining budget is short-circuited; the tool call returns a
+`BudgetExceededError` and the parent's loop continues with that
+information.
+
+Pricing rules (`PricingConfig`) are evaluated *at the subagent's
+endpoint*, not at the parent's. A subagent talking to a more
+expensive model costs more, and that cost flows correctly to the
+parent's budget.
+
+### OTEL spans
+
+The remote transport creates a child span under the parent's current
+span. Span attributes:
+
+- `subagent.name` — the subagent identifier.
+- `subagent.transport` — `remote` or `inprocess`.
+- `subagent.depth` — current delegation depth.
+- `subagent.permission_scope` — the named scope under which the
+  subagent ran.
+- `subagent.tokens_used` — tokens consumed.
+- `subagent.cost_usd` — dollar cost.
+- `error.type` — populated on failure (`Timeout`, `MaxDepth`,
+  `RemoteCrash`, `BudgetExceeded`).
+
+Inprocess transport spans are emitted similarly, with
+`subagent.transport: inprocess`.
+
+The W3C Trace Context propagation ensures that the receiving
+subagent's OTEL spans are children of the parent's, so the entire
+delegation tree is reconstructable in any OTLP-compatible viewer.
+
+### Structured logs
+
+Every delegation emits a structured log line at start and end:
+
+```json
+{
+  \"event\": \"subagent.invoked\",
+  \"parent_session_id\": \"sess_abc\",
+  \"parent_message_index\": 14,
+  \"agent_name\": \"research_helper\",
+  \"depth\": 1,
+  \"transport\": \"remote\"
+}
+```
+
+`parent_message_index` is essential for replay: a debugger can
+identify exactly which assistant turn invoked the subagent.
+
+## Streaming model
+
+### v1 (first PR): buffered
+
+The subagent runs to completion. The tool returns a single
+`SubagentResult`. The parent sees `SubagentInvoked` at the start and
+`SubagentCompleted` at the end of the tool call.
+
+This is the simplest shape and unblocks the headline use cases. It is
+also adequate for ad-hoc delegations where the subagent's intermediate
+output is not interesting to the operator.
+
+### v2 (follow-on): nested deltas
+
+The subagent's `StreamEvent`s are forwarded onto the parent's stream
+as `SubagentDelta` events with the subagent's `agent_name` attached.
+The parent's stream interleaves its own deltas with the subagent's,
+and the gateway / UI can render both — likely as a nested panel or
+threaded view (open question for the UI repo).
+
+The framework requirements for v2:
+
+- `SubagentDelta(agent_name, delta)` carries the original event
+  unmodified except for the namespace.
+- The parent's `astep_stream` consumer treats `SubagentDelta` as
+  opaque — the gateway is responsible for routing deltas back to
+  the right rendering surface.
+- Backpressure: the remote transport reads the SSE stream as fast as
+  the subagent emits. The parent's stream is bounded by the existing
+  per-stream queue; if the consumer is slow, deltas drop with a
+  `SubagentDeltaDropped` warning event. Retrofitting this onto v1's
+  buffered model is non-breaking — v1 simply skips deltas.
+- Buffered subagent results remain available even when streaming; the
+  final `SubagentCompleted` event carries the same payload as the
+  v1 tool result.
+
+## Error handling
+
+Failure modes and their semantics:
+
+- **Timeout (`SubagentTimeoutError`).** The transport's
+  `timeout_seconds` elapsed without the subagent returning. Tool call
+  returns a structured error; the parent's LLM may retry or replan.
+- **Remote crash (`SubagentRemoteError`).** The remote endpoint
+  returned 5xx or the connection broke. Tool call returns a
+  structured error with the upstream status. Retry policy is the
+  parent's loop's responsibility (existing `loop.max_iterations`).
+- **Max depth (`MaxDelegationDepthError`).** The framework detected
+  that this call would exceed the chain's `max_depth`. Tool call
+  returns a structured error; this is non-recoverable for the
+  current delegation path.
+- **Budget exceeded (`BudgetExceededError`).** The parent's budget
+  was exhausted mid-subagent. The subagent is allowed to finish (we
+  do not abort mid-call), but the result includes a budget warning,
+  and the parent's next step terminates if the budget is still
+  blown.
+- **Permission denied (`PermissionDeniedError`).** The intersection
+  of parent and subagent scopes denied the call. Same shape as a
+  normal tool denial under #164.
+- **Inprocess crash (`SubagentCrashedError`).** An exception escaped
+  the inprocess subagent. The framework catches and converts to a
+  structured error so the parent's loop continues cleanly.
+
+Retries are the parent's LLM's job. The framework does not auto-retry
+subagent calls — that conflates failure modes (timeout vs. crash vs.
+denial) that the model should handle differently.
+
+## Tradeoffs
+
+### One tool with `agent_name` parameter, vs. N synthesised tools
+
+**One tool (`delegate_to_agent(agent_name, task, context)`).**
+- Pros: clean schema, constant token cost in the tool list, explicit
+  argument that lets the LLM compose.
+- Cons: discovery requires the LLM to read the `description` and
+  `when_to_use` fields out of the tool schema's free-text section;
+  picking the right subagent is a model-side reasoning step.
+
+**N synthesised tools (one per registered subagent).**
+- Pros: tool descriptions surface naturally in the tool list; the
+  model picks via standard tool selection.
+- Cons: tool list size grows linearly with subagents; on small models
+  (Granite 8B, etc.) this can blow the context budget.
+
+**Recommendation.** Ship one tool with `agent_name`, but synthesise
+auto-generated `when_to_use` hints into the tool description. If real
+deployments find selection unreliable, add a config knob
+`subagent_tool_strategy: single | per_agent` later. The single-tool
+shape is the smaller commitment.
+
+### Static config vs. kagenti-discovered registry
+
+**Static config in `agent.yaml`.**
+- Pros: matches the immutable-image model. Subagents are deployment
+  facts, baked in at scaffold time. Audit-friendly.
+- Cons: rosters are per-agent. Cross-tenant or per-tenant rosters
+  require redeploying.
+
+**kagenti-discovered registry.**
+- Pros: per-tenant rosters, dynamic capability discovery, central
+  governance.
+- Cons: runtime dependency on kagenti for every cold-start; adds a
+  failure mode to agent setup.
+
+**Recommendation.** Start static. Add a `discovery: kagenti` mode in
+the `subagents:` block as a follow-on once the static path proves
+itself. The discovery extension does not break existing configs —
+agents that do not opt in keep the static behaviour.
+
+## Open questions
+
+1. **`agent_name` parameter vs. N synthesised tools.** Tradeoffs above.
+   Defer to first PR; pick one and instrument.
+2. **Subagent registry scoping.** Static-only at first; kagenti
+   discovery as a follow-on.
+3. **kagenti-discovered targets.** Out of scope for v1; design the
+   `discovery: kagenti` extension separately.
+4. **Streaming failure modes.** v2 design needs explicit answers on
+   buffered windowing, backpressure, and partial-delta semantics.
+   These are best decided once the UI's rendering shape is known
+   (issue in `fips-agents/ui-template`).
+5. **Composition with workflow graph.** An `AgentNode` may itself
+   invoke a subagent. Likely fine — `AgentNode` runs a BaseAgent,
+   BaseAgent has the tool. Document the pattern in the workflow
+   docs; no code change needed.
+6. **Inprocess identity scoping.** When transport is `inprocess`, the
+   subagent shares the parent's process and therefore its kagenti
+   identity (no HTTP boundary to override at). Should the framework
+   forbid `identity: service_account: <name>` for inprocess
+   transport, or transparently rebind the identity context for the
+   duration of the call? Lean toward forbid + warn; revisit if real
+   cases show up.
+7. **Sub-subagent depth accounting.** `max_depth` is set on the first
+   subagent in a chain. Is that the right shape, or should each
+   subagent in the chain be able to set its own cap (with min
+   wins)? Lean toward chain-root cap for simplicity.
+8. **Resilience to subagent restarts.** If a remote subagent rolls
+   over mid-call, retries that succeed land in a fresh process —
+   acceptable, but worth documenting that subagents must be
+   stateless or session-aware to be re-callable.
+
+## Out of scope
+
+- **A subagent marketplace or registry service.** The registry is
+  per-agent config, baked in at deploy time. Cross-agent discovery
+  is `fipsagents-platform`'s concern, not this issue's.
+- **Cross-tenant subagent routing.** Identity boundary is kagenti's
+  job; the framework does not auto-route across tenants.
+- **v2 streaming.** Roadmap only; v1 ships buffered.
+- **Subagent-driven workflow rewriting.** The graph stays static.
+  Subagents do not rewrite the workflow's edges.
+- **Multi-modal subagent payloads beyond what tool calls already
+  support.** If a subagent takes a file or image argument, that goes
+  through the existing `file_ids` / multimodal path, not a new
+  subagent-specific channel.
+
+## Related
+
+- Issue #165 — the feature ticket this design backs.
+- Issue #164 — per-tool permission policy; required for
+  `permission_scope`.
+- Issue #163 — Question tool; soft dependency for \"ask before
+  delegating\" patterns.
+- `RemoteNode` in `fipsagents.workflow` — transport prototype.
+- `propagation.py` in `fipsagents.server` — W3C Trace Context.
+- UI rendering for subagents (issue in `fips-agents/ui-template`) —
+  open design questions on the rendering side; final shape is
+  decided after v1 ships and we have real telemetry to ground the
+  discussion.


### PR DESCRIPTION
## Summary

- `docs/responsibilities.md` — contributor-facing scope and non-goals doc. Establishes what each adjacent platform layer owns (OGX, kagenti, MemoryHub, OpenShift, inference, sibling fips-agents repos), explicit non-goals (TUI, IDE bridges, coding-specific tools, ACP, plugin runtimes, share URLs), and the extensions story for domain-specific capabilities (FHIR, OData, code-tools, ...).
- `planning/subagent-tool-design.md` — full design doc for the subagent-as-tool feature. Covers `subagents:` config block, remote/inprocess transports, conversation isolation, permission propagation (parent scope is upper bound), kagenti identity inheritance, cost/trace roll-up, v1 buffered vs v2 streaming, error and depth handling.

## Related

- #165 — feat: subagent-as-tool (the design doc's tracking issue)
- #170 — [arch] template extensions / add-ons mechanism (referenced from the responsibilities doc)

## Test plan

Documentation only; no automated tests apply. Manual review of both files.