### PR TITLE
docs: subagent-as-tool architecture subsection + 0.22.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-07
+
+Subagent-as-tool: composable delegation through the tool plane. Closes the bulk of [#165](https://github.com/fips-agents/agent-template/issues/165).
+
+### Added
+
+- **`subagents:` config block on `AgentConfig`** ([#165](https://github.com/fips-agents/agent-template/issues/165), [#173](https://github.com/fips-agents/agent-template/pull/173)). New `SubagentConfig` (with `RemoteTransportConfig` / `InProcessTransportConfig` discriminated union, `IdentityServiceAccount`, and validators rejecting `inprocess` + `service_account` and duplicate names) lets a parent agent declare peer agents the LLM may delegate to. `BaseAgent.setup()` auto-registers a stock `delegate_to_agent` tool when the list is non-empty; agents with no subagents pay nothing.
+- **`fipsagents.subagents` package** ([#165](https://github.com/fips-agents/agent-template/issues/165)). New `SubagentResult` dataclass plus a `SubagentError` hierarchy (`SubagentTimeoutError`, `SubagentRemoteError`, `MaxDelegationDepthError`, `SubagentCrashedError`). `SubagentTransport` ABC with two concrete implementations: `RemoteSubagentTransport` (HTTP POST to `/v1/chat/completions` with `stream=False`, OpenAI-compatible request shape, W3C `traceparent` injection, `Authorization` forwarding for `identity: inherit`) and `InProcessSubagentTransport` (imports the subagent class via `class_path`, runs `astep_stream` to completion, propagates `x-subagent-depth` in-band).
+- **`delegate_to_agent` stock tool** ([#165](https://github.com/fips-agents/agent-template/issues/165)). Closure-based factory in `fipsagents.baseagent.subagent_tool` that captures the agent instance for `subagents` registry resolution, depth-cap enforcement against `_delegation_depth`, transport selection, header construction, and event emission. Returns the `SubagentResult` to the LLM as a JSON string. Registered via `ToolRegistry.register` from `BaseAgent.setup()` step 4a.
+- **Subagent `StreamEvent` variants** ([#165](https://github.com/fips-agents/agent-template/issues/165)). `SubagentInvoked`, `SubagentCompleted`, `SubagentFailed` are emitted by the delegation tool and drained from `agent._subagent_events` inside `astep_stream` between `tools.execute()` and `ToolResultEvent`. `SubagentDelta` is forward-compat for v2 nested streaming -- no emitter in v1. The OpenAI SSE serializer maps all four onto a `subagent` top-level delta field.
+- **Parent-side cost roll-up via `_persist_cost_data`** ([#165](https://github.com/fips-agents/agent-template/issues/165)). The delegation tool appends each subagent's `tokens_used` to `agent._subagent_token_usage`; `OpenAIChatServer._persist_cost_data` drains the buffer into the turn's `cost_data` write before the session-store update. `BudgetEnforcer` -- which reads `cost_data` on its next pre-request check -- sees rolled-up totals across both the parent's own LLM calls and any subagent invocations.
+- **Inbound `Authorization` header forwarding** ([#165](https://github.com/fips-agents/agent-template/issues/165)). `OpenAIChatServer._chat_completions` sets `agent._inbound_auth_header` from the incoming request and clears it in `finally` (both the sync and streaming paths). When `identity: inherit`, the delegation tool forwards this header to remote subagents so the chain runs under the caller's identity.
+- **Commented-out `subagents:` example in the agent-loop template `agent.yaml`** ([#165](https://github.com/fips-agents/agent-template/issues/165)). Documents both transport types with `${VAR:-default}` env-var substitution and explicitly calls out the v1 permission gap (`permission_scope` parsed but not enforced until [#164](https://github.com/fips-agents/agent-template/issues/164)).
+
+### Notes
+
+- **Streaming is buffered in v1.** The parent waits for the subagent to finish and sees a single tool result. The `SubagentDelta` event is defined and round-trips through the SSE serializer so consumers can pattern-match exhaustively, but no code path emits it. Nested-delta streaming arrives once the UI rendering shape is known (see `fips-agents/ui-template`).
+- **Permission enforcement is gated on [#164](https://github.com/fips-agents/agent-template/issues/164).** `permission_scope` is parsed and validated for shape but does not gate calls. A `WARNING` is logged once per `(agent, agent_name)` so the gap is visible. The follow-up PR will plug enforcement into the existing permission policy hook without requiring a config change.
+- **Registry is static.** Subagents are deployment facts baked into `agent.yaml`. kagenti-driven dynamic discovery (`discovery: kagenti` mode) is a follow-up that will not break existing configs.
+- **`identity: service_account` is rejected for inprocess transport** at config-validation time (no HTTP boundary at which to override identity). The Pydantic `model_validator` raises a specific error message pointing at the two valid alternatives.
+- **Depth enforcement is parent-side only on the inprocess path.** `x-subagent-depth` propagates in-band so an inprocess sub-subagent can detect chain depth, but the receiving end of remote chains does not yet read the header on inbound. Remote chain-depth enforcement is a follow-up.
+- **Stock tools currently live as functions inside `baseagent/tools.py`, not as one-file-per-tool under a `tools/` package** ([#174](https://github.com/fips-agents/agent-template/issues/174)). The closure-based factory in `subagent_tool.py` works but doesn't scale to additional stock tools. Tracked as a follow-up; no API change for users.
+
 ## [0.21.1] - 2026-05-05
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,6 +137,29 @@ The `guardrails` field is an OGX extension to the Responses API and is not recog
 
 Platform mode is decoupled from observability (#81). When that issue lands, OTLP wiring will apply uniformly to both chat-completions and Responses-based agents.
 
+### Subagent-as-tool
+
+Subagent-as-tool is composable delegation through the tool plane: a parent agent declares peer agents in `agent.yaml` under `subagents:`, and `BaseAgent.setup()` auto-registers a stock `delegate_to_agent(agent_name, task, context)` tool. The LLM picks a subagent at runtime and the framework handles transport, trace propagation, identity forwarding, parent-side cost roll-up, and depth bounds. This is intentionally orthogonal to the workflow graph -- workflows remain the right shape when topology is known up front and the graph itself encodes business logic; subagent-as-tool is the right shape when the parent decides *at runtime* whether to delegate based on the user's intent.
+
+When `subagents:` is non-empty:
+
+- `BaseAgent.setup()` builds `self.subagents: dict[str, SubagentConfig]` and registers a per-agent closure-based `delegate_to_agent` via `ToolRegistry.register`. Agents with no subagents pay nothing -- the tool is not registered, the schema is not surfaced, and the LLM sees no extra option.
+- The parent's `astep_stream` drains a `_subagent_events` buffer between `tools.execute()` and `ToolResultEvent`, yielding `SubagentInvoked` → `SubagentCompleted` (or `SubagentFailed`) before the tool result so consumers see the lifecycle in cause-and-effect order.
+- `OpenAIChatServer._persist_cost_data` drains `agent._subagent_token_usage` into the turn's `cost_data` write so `BudgetEnforcer` (which reads `cost_data` on its next pre-request check) sees rolled-up totals across both the parent's own LLM calls and any subagent invocations.
+
+Two transports are supported, validated by a Pydantic discriminated union on `transport.type`:
+
+- **`remote`** -- HTTP POST to the target's `/v1/chat/completions` with `stream=False`. The wire shape is standard OpenAI chat completions; the response's `usage` block populates `SubagentResult.tokens_used`. Outgoing headers always include `x-subagent-depth` (caller's depth + 1) and a synthesised W3C `traceparent` derived from the call's span id; `Authorization` is forwarded when `identity: inherit` and the parent received an inbound auth header.
+- **`inprocess`** -- imports the subagent class via `class_path`, calls `setup()` once, runs `astep_stream` to completion, and assembles a `SubagentResult` from the collected events. Trace headers are ignored (no HTTP boundary) but `x-subagent-depth` *is* propagated in-band so an inprocess sub-subagent can detect chain depth.
+
+`identity: service_account: <name>` is reserved for kagenti-issued credentials and is rejected at config-validation time when paired with `inprocess` transport (no HTTP boundary at which to override identity). `permission_scope` is parsed but not enforced in v1 -- it logs a single `WARNING` per `(agent, agent_name)` until per-tool permission policy lands (#164).
+
+Four new `StreamEvent` variants land on the union: `SubagentInvoked`, `SubagentCompleted`, `SubagentFailed`, and `SubagentDelta` (forward-compat for v2 nested streaming, no emitter in v1). The OpenAI SSE serializer maps them onto a `subagent` top-level delta field, mirroring how `GuardrailFiredEvent` handles non-standard payloads.
+
+Failure modes surface as concrete `SubagentError` subclasses -- `SubagentTimeoutError`, `SubagentRemoteError`, `MaxDelegationDepthError`, `SubagentCrashedError` -- so the parent's LLM can branch on type and replan. The existing server-layer `BudgetExceededError` is reused for budget exhaustion. Retries are the parent's loop's responsibility; the framework does not auto-retry subagent calls because retrying conflates failure modes (timeout vs. crash vs. denial) the model should handle differently.
+
+v1 ships buffered: the parent waits for the subagent to finish and sees a single tool result. Nested-delta streaming (the `SubagentDelta` event), kagenti-driven dynamic registries, and remote-chain depth enforcement (the receiver reading `x-subagent-depth` on inbound) are scoped as follow-ups. Full design lives in `planning/subagent-tool-design.md`.
+
 ### Prompts
 
 `load_prompt(name, **variables)` loads a prompt from the `prompts/` directory, performs variable substitution, and returns the rendered text. `list_prompts()` returns available prompts with their metadata. The prompt format is described in its own section below.

--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fipsagents"
-version = "0.21.1"
+version = "0.22.0"
 description = "Production-ready AI agent framework for FIPS/OpenShift environments"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
## Summary

Two-part follow-up to #173 (subagent-as-tool v1, merged as `49365fa`):

- **Architecture doc backfill.** `docs/architecture.md` is the canonical reference (per the project `CLAUDE.md`) but had no mention of subagents or `delegate_to_agent`. Adds a new "Subagent-as-tool" subsection right after "Platform Mode (OGX delegation)", mirroring its shape (opt-in switch → when-enabled behaviour → transport semantics → scope cuts → link to the design doc).
- **Version bump 0.21.1 → 0.22.0** with a CHANGELOG entry. Subagent-as-tool added new public config (`subagents:`), a new package (`fipsagents.subagents`), new `StreamEvent` variants, and a new stock tool — minor bump under semver.

`sandbox/` was already pruned from `main` in earlier work — no directory removal needed (the gitleaks findings session-close flagged are in historical commits only).

## Test plan

- [x] `pytest -q` clean (no source changes; only docs + version)
- [x] `gitleaks protect --staged` clean
- [x] `agent.yaml` template still parses (config schema didn't change)