### PR TITLE
feat: implicit-open mode in ThinkTagParser + nemotron in matcher

### DIFF
--- a/packages/fipsagents/src/fipsagents/baseagent/reasoning.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/reasoning.py
@@ -9,6 +9,14 @@ blocks so ``astep_stream`` can emit ``ReasoningDelta`` for thinking and
 When vLLM is started with ``--reasoning-parser granite``, it does this
 extraction server-side and populates ``reasoning_content`` directly.
 The parser is a fallback for deployments that don't set that flag.
+
+A subset of reasoning-tuned models — Nemotron-Nano-9B-v2 is the
+canonical example — apply a chat template that implicitly opens
+``<think>`` before the assistant's turn, so the model only ever emits
+the closing ``</think>`` plus the user-visible answer. For these
+models, construct ``ThinkTagParser(implicit_open=True)``: the parser
+starts already inside a think block and transitions to content on
+the first ``</think>``.
 """
 
 from __future__ import annotations
@@ -42,16 +50,29 @@ class ThinkTagParser:
     in a single response.
     """
 
-    __slots__ = ("_buf", "_in_think")
+    __slots__ = ("_buf", "_in_think", "_implicit_open")
 
-    def __init__(self) -> None:
+    def __init__(self, *, implicit_open: bool = False) -> None:
+        """Construct a parser.
+
+        Parameters
+        ----------
+        implicit_open:
+            When ``True``, start already inside a think block. Use for
+            models whose chat template emits the opening ``<think>``
+            tag for them, leaving only ``</think>`` + final answer in
+            the assistant content stream (eg Nemotron-Nano-9B-v2).
+            Defaults to ``False`` (the original behaviour: wait for an
+            explicit ``<think>``).
+        """
         self._buf = ""
-        self._in_think = False
+        self._implicit_open = implicit_open
+        self._in_think = implicit_open
 
     def reset(self) -> None:
         """Reset parser state between model calls."""
         self._buf = ""
-        self._in_think = False
+        self._in_think = self._implicit_open
 
     def feed(self, text: str) -> list[tuple[str, str]]:
         """Process a content delta and return separated segments."""
@@ -118,4 +139,10 @@ def create_reasoning_parser(model_name: str) -> ThinkTagParser | None:
     name = model_name.lower()
     if "granite" in name or "deepseek" in name:
         return ThinkTagParser()
+    if "nemotron" in name:
+        # Nemotron-Nano-9B-v2 (and other Nemotron reasoning variants
+        # observed so far) apply a chat template that implicitly opens
+        # ``<think>`` before the assistant turn — the model only emits
+        # the closing tag and the final answer.
+        return ThinkTagParser(implicit_open=True)
     return None

--- a/packages/fipsagents/tests/test_reasoning_parser.py
+++ b/packages/fipsagents/tests/test_reasoning_parser.py
@@ -144,6 +144,96 @@ def test_returns_none_for_openai():
     assert create_reasoning_parser("gpt-4o") is None
 
 
+def test_creates_implicit_open_parser_for_nemotron():
+    """Nemotron's chat template opens <think> implicitly; parser must start
+    already inside a think block."""
+    parser = create_reasoning_parser("nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8")
+    assert isinstance(parser, ThinkTagParser)
+    # Empirically: a Nemotron stream starts with reasoning content and the
+    # first explicit tag the model emits is the closing </think>.
+    result = parser.feed("Okay, let me think about this...</think>final answer")
+    assert result == [
+        ("reasoning", "Okay, let me think about this..."),
+        ("content", "final answer"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# implicit_open mode
+# ---------------------------------------------------------------------------
+
+
+def test_implicit_open_starts_in_think_state():
+    """Parser constructed with implicit_open=True treats opening content as
+    reasoning until the first </think>."""
+    p = ThinkTagParser(implicit_open=True)
+    result = p.feed("thinking out loud</think>visible answer")
+    assert result == [
+        ("reasoning", "thinking out loud"),
+        ("content", "visible answer"),
+    ]
+
+
+def test_implicit_open_handles_chunked_thinking():
+    """Reasoning split across chunks accumulates correctly before the close."""
+    p = ThinkTagParser(implicit_open=True)
+    assert p.feed("first chunk ") == [("reasoning", "first chunk ")]
+    assert p.feed("second chunk") == [("reasoning", "second chunk")]
+    assert p.feed("</think>answer") == [("content", "answer")]
+
+
+def test_implicit_open_close_tag_split_across_chunks():
+    """Close-tag boundary handling still works with implicit_open=True."""
+    p = ThinkTagParser(implicit_open=True)
+    # "</thi" is held back as a possible close-tag prefix.
+    assert p.feed("thinking</thi") == [("reasoning", "thinking")]
+    assert p.feed("nk>answer") == [("content", "answer")]
+
+
+def test_implicit_open_subsequent_think_block_recognised():
+    """After the implicit block closes, a subsequent explicit <think>...</think>
+    is parsed normally — the parser is a regular state machine again once
+    the implicit block ends."""
+    p = ThinkTagParser(implicit_open=True)
+    result = p.feed("first thoughts</think>answer<think>more thoughts</think>more answer")
+    assert result == [
+        ("reasoning", "first thoughts"),
+        ("content", "answer"),
+        ("reasoning", "more thoughts"),
+        ("content", "more answer"),
+    ]
+
+
+def test_implicit_open_reset_returns_to_in_think():
+    """reset() between turns must restore the implicit-open initial state,
+    not the default not-in-think state."""
+    p = ThinkTagParser(implicit_open=True)
+    p.feed("first turn thoughts</think>first turn answer")
+    p.reset()
+    # Next turn: again starts inside think.
+    result = p.feed("second turn thoughts</think>second turn answer")
+    assert result == [
+        ("reasoning", "second turn thoughts"),
+        ("content", "second turn answer"),
+    ]
+
+
+def test_implicit_open_unclosed_still_emits_as_reasoning():
+    """Stream that ends without </think> emits everything as reasoning."""
+    p = ThinkTagParser(implicit_open=True)
+    result = p.feed("thinking forever and ever")
+    assert result == [("reasoning", "thinking forever and ever")]
+    assert p.flush() == []
+
+
+def test_default_constructor_unchanged():
+    """Backward compatibility: ThinkTagParser() with no args behaves
+    identically to the pre-implicit_open implementation."""
+    p = ThinkTagParser()
+    # Plain content with no tags is content, not reasoning.
+    assert p.feed("just some content") == [("content", "just some content")]
+
+
 # ---------------------------------------------------------------------------
 # Integration: astep_stream separates think tags end-to-end
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A subset of reasoning-tuned models — `Nemotron-Nano-9B-v2` (and other Nemotron reasoning variants) — apply a chat template that implicitly opens `<think>` before the assistant's turn. The model only ever emits the closing `</think>` plus the user-visible answer. The current `ThinkTagParser` waits for an explicit opening `<think>` and never enters reasoning mode for these models, so the entire chain-of-thought leaks into the user-visible content stream as plain text.

This PR adds an opt-in `implicit_open=True` flag to `ThinkTagParser` that starts it already inside a think block, and matches `"nemotron"` in `create_reasoning_parser` to return an implicit-open parser for these models.

## Reproduction

Direct call to a `vllm serve` of `nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8`:

```bash
curl -s "$ENDPOINT/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{"model":"nemotron-9b","messages":[{"role":"user","content":"What is 17 * 23? Show your reasoning."}]}'
```

```
{
  "choices": [{
    "message": {
      "content": "Okay, let's see. I need to calculate 17 multiplied by 23. Hmm, how should I approach this?... 17 times 25...the</think>\n\n[final answer]",
      "reasoning_content": null
    }
  }]
}
```

Note: `</think>` is present, `<think>` is not, and `reasoning_content` is `null`. Without the fix, all of the model's thinking lands in `delta.content` — and from there into the assistant message that gets fed back on subsequent turns, polluting the conversation.

## Behaviour after the change

`create_reasoning_parser("nvidia/NVIDIA-Nemotron-Nano-9B-v2-FP8")` returns a `ThinkTagParser(implicit_open=True)`. End-to-end through `astep_stream`, the streamed model output above produces:

- `delta.reasoning_content`: `Okay, let's see. I need to calculate ...`
- `delta.content`: `[final answer]`

The framework's existing UI conventions (collapsible Thinking panel for `ReasoningDelta`, visible body for `ContentDelta`) work without further changes.

## Implementation notes

**Flag, not subclass.** Added a single keyword-only `implicit_open: bool = False` to `__init__`, extended `__slots__` to track it, and made `reset()` restore the implicit-open state so each `astep_stream` iteration that calls `parser.reset()` re-enters the right initial state for the next turn.

**Once the implicit block closes** (on the first `</think>`), the parser becomes an ordinary state machine. A subsequent explicit `<think>...</think>` in the same turn is recognised normally — covered by `test_implicit_open_subsequent_think_block_recognised`.

**Backward compatibility.** `ThinkTagParser()` with no args behaves identically to before. All 13 existing parser tests pass unchanged. The integration test `test_astep_stream_separates_think_tags` still passes.

## Tests

8 new test functions in `packages/fipsagents/tests/test_reasoning_parser.py`:

- `test_creates_implicit_open_parser_for_nemotron` — factory matches a Nemotron model name and the returned parser parses an implicit-open stream correctly
- `test_implicit_open_starts_in_think_state` — basic `feed("text</think>answer")` produces the expected split
- `test_implicit_open_handles_chunked_thinking` — multi-chunk reasoning accumulates
- `test_implicit_open_close_tag_split_across_chunks` — close-tag boundary handling preserved
- `test_implicit_open_subsequent_think_block_recognised` — after the implicit close, an explicit `<think>...</think>` still works
- `test_implicit_open_reset_returns_to_in_think` — `reset()` between turns restores implicit-open initial state
- `test_implicit_open_unclosed_still_emits_as_reasoning` — graceful handling of streams that never close
- `test_default_constructor_unchanged` — explicit backward-compat assertion

All 25 tests in `test_reasoning_parser.py` pass.

## Out of scope

**Gemma's thinking format.** Gemma's reasoning-mode output uses raw special tokens rather than `<think>...</think>` tags ([reference](https://ai.google.dev/gemma/docs/capabilities/thinking)), which calls for a different parser entirely. Filing as a follow-up issue once the Nemotron path is in.

## In-the-wild override

A downstream consumer is currently carrying this same change locally as a `BaseAgent` subclass override that swaps in an implicit-open parser when the model name contains `nemotron`. Reference implementation (the same logic, expressed at the application layer): https://github.com/rdwj/cdc-data-acceptance-testing/blob/c13a47d/agent/cdc-agent/src/agent.py — see `ImplicitOpenThinkTagParser` and the parser-swap in `setup()`. Once this PR lands, that override becomes redundant and can be deleted.

## Test plan

- [x] `pytest packages/fipsagents/tests/test_reasoning_parser.py` — 25 passed
- [ ] Verified end-to-end against a deployed `Nemotron-Nano-9B-v2-FP8` endpoint via `--reasoning-parser` not being set on vLLM (so the framework parser is responsible for the split): the assistant message in subsequent turns no longer contains chain-of-thought preamble; `delta.reasoning_content` carries the thinking.