### PR TITLE
ci: bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -23,7 +23,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: packages/fipsagents/dist/
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6, `actions/setup-python` v5 → v6, `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v8
- All four now declare `using: node24`, ahead of the June 2 deprecation cutover
- `pypa/gh-action-pypi-publish` is Docker-based and unaffected

Closes #176

## Test plan

- [ ] Merge and tag a `fipsagents-v*` release (or push a test tag) to exercise the workflow end-to-end
- [ ] Verify the build and publish jobs complete without Node.js deprecation warnings