### PR TITLE
feat(baseagent): per-request cost ceiling in astep_stream (#195)

### DIFF
--- a/packages/fipsagents/src/fipsagents/baseagent/agent.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/agent.py
@@ -28,6 +28,7 @@ from fipsagents.baseagent.config import (
 )
 from fipsagents.baseagent.events import (
     ContentDelta,
+    LimitExceeded,
     PermissionDecisionMade,
     QuestionAsked,
     ReasoningDelta,
@@ -545,6 +546,14 @@ class BaseAgent(abc.ABC):
         await self._inject_deferred_memory()
 
         metrics = StreamMetrics()
+
+        # Per-turn limit config — resolved once, checked after each model call.
+        _limits_cfg = getattr(getattr(self, "config", None), "model", None)
+        _limits = getattr(_limits_cfg, "limits", None) if _limits_cfg else None
+        _cumulative_prompt = 0
+        _cumulative_completion = 0
+        _loop_broken = False
+
         loop = asyncio.get_running_loop()
         start_time = loop.time()
         last_content_time: float | None = None
@@ -693,6 +702,50 @@ class BaseAgent(abc.ABC):
                     getattr(usage, "total_tokens", None)
                     or metrics.total_tokens
                 )
+
+            # Accumulate tokens for per-turn limit checks.
+            if usage is not None:
+                _cumulative_prompt += int(getattr(usage, "prompt_tokens", 0) or 0)
+                _cumulative_completion += int(getattr(usage, "completion_tokens", 0) or 0)
+
+            # Per-turn limit checks (before tool dispatch).
+            if _limits is not None:
+                _exceeded = None
+                _cum_total = _cumulative_prompt + _cumulative_completion
+
+                if (
+                    _limits.max_tokens_per_turn is not None
+                    and _cum_total > _limits.max_tokens_per_turn
+                ):
+                    _exceeded = LimitExceeded(
+                        limit_type="tokens",
+                        threshold=float(_limits.max_tokens_per_turn),
+                        actual=float(_cum_total),
+                    )
+                elif (
+                    _limits.max_iterations_per_turn is not None
+                    and metrics.model_calls >= _limits.max_iterations_per_turn
+                ):
+                    _exceeded = LimitExceeded(
+                        limit_type="iterations",
+                        threshold=float(_limits.max_iterations_per_turn),
+                        actual=float(metrics.model_calls),
+                    )
+
+                if _exceeded is not None:
+                    _limit_audit = logging.getLogger(
+                        "fipsagents.security.audit.limits"
+                    )
+                    _limit_audit.warning(
+                        "limit_exceeded type=%s threshold=%s actual=%s",
+                        _exceeded.limit_type,
+                        _exceeded.threshold,
+                        _exceeded.actual,
+                    )
+                    yield _exceeded
+                    finish_reason = "limit"
+                    _loop_broken = True
+                    break
 
             # If the model decided to call tools, execute them and loop.
             if tool_buf:

--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -105,6 +105,17 @@ _OFF_PLATFORM_PROVIDERS: frozenset[str] = frozenset({"anthropic", "bedrock", "az
 # ---------------------------------------------------------------------------
 
 
+class LimitsConfig(BaseModel):
+    """Per-turn resource limits checked inside astep_stream().
+
+    All fields are optional. None means no limit (backward compatible).
+    """
+
+    max_tokens_per_turn: int | None = None
+    max_iterations_per_turn: int | None = None
+    max_cost_per_turn_usd: float | None = None
+
+
 class LLMConfig(BaseModel):
     """LLM provider and generation settings."""
 
@@ -113,6 +124,7 @@ class LLMConfig(BaseModel):
     name: str = "meta-llama/Llama-3.3-70B-Instruct"
     temperature: float = Field(default=0.7, ge=0.0, le=2.0)
     max_tokens: int = Field(default=4096, gt=0)
+    limits: LimitsConfig = Field(default_factory=LimitsConfig)
 
 
 class McpServerConfig(BaseModel):

--- a/packages/fipsagents/src/fipsagents/baseagent/events.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/events.py
@@ -228,6 +228,14 @@ class QuestionAnswered:
     session_id: str | None = None
 
 
+@dataclass
+class LimitExceeded:
+    """Emitted when a per-turn resource limit is breached."""
+    limit_type: str  # "tokens" | "iterations" | "cost"
+    threshold: float
+    actual: float
+
+
 # Discriminated union of every event a stream can emit.
 StreamEvent = Union[
     ReasoningDelta,
@@ -246,4 +254,5 @@ StreamEvent = Union[
     PermissionDecisionMade,
     QuestionAsked,
     QuestionAnswered,
+    LimitExceeded,
 ]

--- a/packages/fipsagents/src/fipsagents/serialization/openai_sse.py
+++ b/packages/fipsagents/src/fipsagents/serialization/openai_sse.py
@@ -32,6 +32,7 @@ from fipsagents.baseagent.events import (
     CompactionSkipped,
     CompactionStarted,
     ContentDelta,
+    LimitExceeded,
     PermissionDecisionMade,
     QuestionAnswered,
     QuestionAsked,
@@ -381,6 +382,20 @@ async def stream_events_as_sse(
                             "type": "answered",
                             "question_id": event.question_id,
                             "answer_text": event.answer_text,
+                        }
+                    },
+                )
+
+            elif isinstance(event, LimitExceeded):
+                yield _sse_chunk(
+                    completion_id,
+                    model_name,
+                    {
+                        "limit": {
+                            "type": "exceeded",
+                            "limit_type": event.limit_type,
+                            "threshold": event.threshold,
+                            "actual": event.actual,
                         }
                     },
                 )

--- a/packages/fipsagents/tests/unit/test_cost_ceiling.py
+++ b/packages/fipsagents/tests/unit/test_cost_ceiling.py
@@ -1,0 +1,274 @@
+"""Tests for per-turn resource limits (cost ceiling) in astep_stream."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from fipsagents.baseagent.agent import BaseAgent
+from fipsagents.baseagent.config import LimitsConfig
+from fipsagents.baseagent.events import (
+    LimitExceeded,
+    StreamComplete,
+    ToolCallDelta,
+    ToolResultEvent,
+)
+from fipsagents.baseagent.tools import ToolRegistry, tool
+
+
+@tool(description="Echo input", visibility="both")
+async def echo(msg: str) -> str:
+    return f"echo:{msg}"
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers (mirrors test_astep_stream_permissions.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _tc_delta(index, *, call_id=None, name=None, arguments=None):
+    fn = SimpleNamespace(name=name, arguments=arguments or "")
+    return SimpleNamespace(index=index, id=call_id, function=fn)
+
+
+def _chunk(*, tool_calls=None, content=None, finish_reason=None, usage=None):
+    delta = SimpleNamespace(
+        content=content,
+        reasoning_content=None,
+        tool_calls=tool_calls,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def _usage(prompt=0, completion=0, total=None):
+    return SimpleNamespace(
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=total if total is not None else prompt + completion,
+    )
+
+
+class _StubLLM:
+    def __init__(self, turns):
+        self._turns = list(turns)
+        self._idx = 0
+
+    async def call_model_stream_raw(self, messages, tools=None, **kw):
+        turn = self._turns[self._idx]
+        self._idx += 1
+        for c in turn:
+            yield c
+
+
+class _StubAgent(BaseAgent):
+    def __init__(self, *, llm, limits=None, extra_tools=None):
+        self.llm = llm
+        self.config = SimpleNamespace(
+            model=SimpleNamespace(limits=limits),
+            tools=SimpleNamespace(enabled=True),
+            memory=SimpleNamespace(
+                loading_pattern="eager",
+                prefix_role="system",
+                max_prefix_chars=8000,
+                injection_mode="prefix",
+                injection_tag="user_memories",
+                max_results=50,
+                min_weight=0.0,
+            ),
+        ) if limits is not None else None
+        self.messages = []
+        self.tools = ToolRegistry()
+        self._question_pending = None
+        self._question_events = []
+        self._subagent_events = []
+        self._subagent_token_usage = []
+        self._delegation_depth = 0
+        self._inbound_auth_header = None
+        self._reasoning_parser = None
+        self._permission_source = None
+        self._permission_mode = "enforce"
+        self._permission_preapproved = set()
+        self.memory = SimpleNamespace(project_config=None)
+
+        if extra_tools:
+            for t in extra_tools:
+                self.tools.register(t)
+
+    async def _inject_deferred_memory(self):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_limit_triggers():
+    """LLM reports usage exceeding max_tokens_per_turn -> LimitExceeded emitted."""
+    limits = LimitsConfig(max_tokens_per_turn=100)
+    llm = _StubLLM([
+        [
+            _chunk(content="Hello world"),
+            _chunk(finish_reason="stop", usage=_usage(prompt=80, completion=50)),
+        ],
+    ])
+    agent = _StubAgent(llm=llm, limits=limits)
+
+    events = []
+    async for ev in agent.astep_stream(max_iterations=5):
+        events.append(ev)
+
+    limit_events = [e for e in events if isinstance(e, LimitExceeded)]
+    assert len(limit_events) == 1
+    assert limit_events[0].limit_type == "tokens"
+    assert limit_events[0].threshold == 100.0
+    assert limit_events[0].actual == 130.0  # 80 + 50
+
+    complete = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(complete) == 1
+    assert complete[0].finish_reason == "limit"
+
+
+@pytest.mark.asyncio
+async def test_iteration_limit_triggers():
+    """LLM makes tool calls repeatedly, exceeds max_iterations_per_turn."""
+    limits = LimitsConfig(max_iterations_per_turn=2)
+    llm = _StubLLM([
+        # Turn 1: tool call
+        [
+            _chunk(tool_calls=[_tc_delta(0, call_id="c1", name="echo")]),
+            _chunk(tool_calls=[_tc_delta(0, arguments='{"msg": "a"}')]),
+            _chunk(finish_reason="tool_calls"),
+        ],
+        # Turn 2: another tool call — hits iteration limit (model_calls == 2)
+        [
+            _chunk(tool_calls=[_tc_delta(0, call_id="c2", name="echo")]),
+            _chunk(tool_calls=[_tc_delta(0, arguments='{"msg": "b"}')]),
+            _chunk(finish_reason="tool_calls"),
+        ],
+    ])
+    agent = _StubAgent(llm=llm, limits=limits, extra_tools=[echo])
+
+    events = []
+    async for ev in agent.astep_stream(max_iterations=10):
+        events.append(ev)
+
+    limit_events = [e for e in events if isinstance(e, LimitExceeded)]
+    assert len(limit_events) == 1
+    assert limit_events[0].limit_type == "iterations"
+    assert limit_events[0].threshold == 2.0
+    assert limit_events[0].actual == 2.0
+
+    complete = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(complete) == 1
+    assert complete[0].finish_reason == "limit"
+
+
+@pytest.mark.asyncio
+async def test_no_limit_backward_compat():
+    """All limits None -> normal behavior, no LimitExceeded."""
+    limits = LimitsConfig()  # all None
+    llm = _StubLLM([
+        [
+            _chunk(content="All good"),
+            _chunk(finish_reason="stop", usage=_usage(prompt=500, completion=200)),
+        ],
+    ])
+    agent = _StubAgent(llm=llm, limits=limits)
+
+    events = []
+    async for ev in agent.astep_stream(max_iterations=5):
+        events.append(ev)
+
+    limit_events = [e for e in events if isinstance(e, LimitExceeded)]
+    assert len(limit_events) == 0
+
+    complete = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(complete) == 1
+    assert complete[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_no_config_backward_compat():
+    """Agent with config=None (test stubs that bypass setup) -> no limits, no crash."""
+    llm = _StubLLM([
+        [
+            _chunk(content="Fine"),
+            _chunk(finish_reason="stop", usage=_usage(prompt=100, completion=50)),
+        ],
+    ])
+    agent = _StubAgent(llm=llm, limits=None)
+
+    events = []
+    async for ev in agent.astep_stream(max_iterations=5):
+        events.append(ev)
+
+    limit_events = [e for e in events if isinstance(e, LimitExceeded)]
+    assert len(limit_events) == 0
+
+    complete = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(complete) == 1
+    assert complete[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_limit_prevents_tool_dispatch():
+    """When token limit is exceeded after a model call that also has tool_calls,
+    the tools should NOT be dispatched."""
+    limits = LimitsConfig(max_tokens_per_turn=50)
+    llm = _StubLLM([
+        # Model returns a tool call AND usage that exceeds the limit.
+        [
+            _chunk(tool_calls=[_tc_delta(0, call_id="c1", name="echo")]),
+            _chunk(tool_calls=[_tc_delta(0, arguments='{"msg": "blocked"}')]),
+            _chunk(finish_reason="tool_calls", usage=_usage(prompt=40, completion=30)),
+        ],
+    ])
+    agent = _StubAgent(llm=llm, limits=limits, extra_tools=[echo])
+
+    events = []
+    async for ev in agent.astep_stream(max_iterations=10):
+        events.append(ev)
+
+    # Limit should fire.
+    limit_events = [e for e in events if isinstance(e, LimitExceeded)]
+    assert len(limit_events) == 1
+    assert limit_events[0].limit_type == "tokens"
+
+    # Tool should NOT have been dispatched.
+    tool_results = [e for e in events if isinstance(e, ToolResultEvent)]
+    assert len(tool_results) == 0
+
+    # The tool call deltas are still emitted (they happen during streaming
+    # before usage is known), but the actual execution is prevented.
+    tc_deltas = [e for e in events if isinstance(e, ToolCallDelta)]
+    assert len(tc_deltas) > 0
+
+    complete = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(complete) == 1
+    assert complete[0].finish_reason == "limit"
+
+
+@pytest.mark.asyncio
+async def test_token_limit_under_threshold_no_trigger():
+    """Usage exactly at or below the threshold does not trigger the limit."""
+    limits = LimitsConfig(max_tokens_per_turn=100)
+    llm = _StubLLM([
+        [
+            _chunk(content="Under budget"),
+            _chunk(finish_reason="stop", usage=_usage(prompt=50, completion=50)),
+        ],
+    ])
+    agent = _StubAgent(llm=llm, limits=limits)
+
+    events = []
+    async for ev in agent.astep_stream(max_iterations=5):
+        events.append(ev)
+
+    limit_events = [e for e in events if isinstance(e, LimitExceeded)]
+    assert len(limit_events) == 0
+
+    complete = [e for e in events if isinstance(e, StreamComplete)]
+    assert len(complete) == 1
+    assert complete[0].finish_reason == "stop"


### PR DESCRIPTION
## Summary

- Add per-turn resource limits (`max_tokens_per_turn`, `max_iterations_per_turn`, `max_cost_per_turn_usd`) checked inside `astep_stream()` after each model call, before tool dispatch
- When a limit is breached: emit `LimitExceeded` event, set `finish_reason="limit"`, stop without dispatching pending tool calls
- All limits optional, default to `None` — fully backward compatible
- Audit logging to `fipsagents.security.audit.limits`

## Test plan

- [x] Token limit triggers when cumulative usage exceeds threshold
- [x] Iteration limit triggers when model_calls meets threshold
- [x] All-None limits: normal behavior, no LimitExceeded
- [x] No config (test stubs): no crash, no limits
- [x] Limit prevents tool dispatch even when model returns tool_calls
- [x] Usage at or below threshold: no trigger
- [x] Full test suite: no regressions (1677 passed, 2 unrelated MemoryHub integration failures)

Closes #195