### PR TITLE
feat(server): LLM-driven auto-compaction on context overflow (#166)

### DIFF
--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -768,6 +768,11 @@ class CompactionConfig(BaseModel):
     enabled: bool = False
     backend: Literal["null", "llm"] | None = None
     threshold_messages: int = Field(default=50, ge=1)
+    keep_recent_turns: int = Field(default=4, ge=1)
+    summary_role: Literal["system", "developer"] = "developer"
+    summary_model: str | None = None
+    context_limit: int = Field(default=0, ge=0)
+    reserve_tokens: int = Field(default=4000, ge=0)
 
     @field_validator("backend", mode="before")
     @classmethod

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import os
 import random
 import re
 import uuid
@@ -335,8 +336,42 @@ class OpenAIChatServer:
         # Initialize compactor.
         from .compactor import create_compactor
         compaction_cfg = getattr(server_cfg, "compaction", None)
-        if compaction_cfg is not None and compaction_cfg.enabled:
-            self._compactor = create_compactor(compaction_cfg.backend)
+        if (
+            compaction_cfg is not None
+            and compaction_cfg.enabled
+            and compaction_cfg.backend == "llm"
+        ):
+            summary_model = (
+                compaction_cfg.summary_model or self._agent.config.model.name
+            )
+            summary_endpoint = self._agent.config.model.endpoint
+
+            async def _compaction_model_fn(messages: list[dict]) -> str:
+                import openai as _oai
+                client = _oai.AsyncOpenAI(
+                    base_url=summary_endpoint or None,
+                    api_key=os.environ.get("OPENAI_API_KEY", "not-required"),
+                )
+                try:
+                    resp = await client.chat.completions.create(
+                        model=summary_model,
+                        messages=messages,
+                        temperature=0.3,
+                        max_tokens=2000,
+                    )
+                    return resp.choices[0].message.content or ""
+                finally:
+                    await client.close()
+
+            self._compactor = create_compactor(
+                compaction_cfg.backend,
+                model_fn=_compaction_model_fn,
+                threshold_messages=compaction_cfg.threshold_messages,
+                keep_recent_turns=compaction_cfg.keep_recent_turns,
+                summary_role=compaction_cfg.summary_role,
+                context_limit=compaction_cfg.context_limit,
+                reserve_tokens=compaction_cfg.reserve_tokens,
+            )
         else:
             self._compactor = create_compactor(None)
 
@@ -1520,6 +1555,51 @@ class OpenAIChatServer:
             },
         )
 
+    # -- Compaction helper ---------------------------------------------------
+
+    async def _maybe_compact(
+        self,
+        agent: BaseAgent,
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Run compaction on ``agent.messages`` if the compactor triggers."""
+        from .compactor import NullCompactor
+
+        if self._compactor is None or isinstance(self._compactor, NullCompactor):
+            return
+
+        # Skip compaction when pending state exists.
+        if session_id and self._session_store:
+            _state = await self._session_store.get_state(session_id)
+            if (
+                _state.get("pending_question")
+                or _state.get("open_tool_calls")
+                or _state.get("pending_subagent_calls")
+            ):
+                logger.debug("Compaction skipped: pending state")
+                return
+
+        if not await self._compactor.should_compact(agent.messages):
+            return
+
+        result = await self._compactor.compact(agent.messages)
+        if not result.skipped:
+            agent.messages = result.messages
+            logger.info(
+                "Compaction: %d -> %d messages",
+                result.original_count,
+                result.compacted_count,
+            )
+            if session_id and self._session_store:
+                import json as _cjson
+                await self._session_store.update_state(
+                    session_id,
+                    compaction_state=_cjson.dumps({"compaction_count": 1}),
+                )
+        else:
+            logger.debug("Compaction skipped: %s", result.skip_reason)
+
     # -- Sync ----------------------------------------------------------------
 
     async def _collect_sync(
@@ -1559,6 +1639,10 @@ class OpenAIChatServer:
                 getattr(_perm_cfg, "mode", "enforce") if _perm_cfg else "enforce"
             )
             agent._permission_preapproved = set()
+
+            # Compaction check (before agent loop).
+            await self._maybe_compact(agent, session_id=session_id)
+
             events = agent.astep_stream(max_iterations=10, **(overrides or {}))
             if self._metrics_collector is not None:
                 events = self._metrics_collector.observe(
@@ -1636,6 +1720,11 @@ class OpenAIChatServer:
                 getattr(_perm_cfg, "mode", "enforce") if _perm_cfg else "enforce"
             )
             self._agent._permission_preapproved = set()
+
+            # Compaction check (before agent loop).
+            await self._maybe_compact(
+                self._agent, session_id=session_id,
+            )
 
             stream_status = "ok"
             captured_metrics: StreamMetrics | None = None

--- a/packages/fipsagents/src/fipsagents/server/compactor.py
+++ b/packages/fipsagents/src/fipsagents/server/compactor.py
@@ -9,6 +9,7 @@ backward-compatible.
 
 from __future__ import annotations
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -89,11 +90,200 @@ class NullCompactor(Compactor):
         )
 
 
+_SUMMARY_PROMPT = """\
+Summarize the following conversation history into a concise briefing. \
+Structure your summary with these sections:
+
+**Goal**: The user's stated objective for this session.
+**Active constraints**: Any "do not do X" or "always Y" directives still in force.
+**Progress**: What has been done and what is in-flight.
+**Decisions made**: Choices committed to by the agent and operator.
+**Pending questions**: Open clarifications awaiting answers.
+**Files/artifacts**: File IDs, document URIs, or prompt names referenced.
+**Last user intent**: The most recent user turn's intent in one sentence.
+
+Be concise. Preserve specific names, IDs, and values. \
+Do not add information that is not in the conversation."""
+
+
+class LLMCompactor(Compactor):
+    """Summarise older messages using an LLM call."""
+
+    def __init__(
+        self,
+        model_fn: Any,
+        *,
+        threshold_messages: int = 50,
+        keep_recent_turns: int = 4,
+        summary_role: str = "developer",
+        context_limit: int = 0,
+        reserve_tokens: int = 4000,
+    ) -> None:
+        self._model_fn = model_fn
+        self._threshold = threshold_messages
+        self._keep_recent = keep_recent_turns
+        self._summary_role = summary_role
+        self._context_limit = context_limit
+        self._reserve_tokens = reserve_tokens
+
+    def _estimate_tokens(self, messages: list[dict[str, Any]]) -> int:
+        return len(str(messages)) // 4
+
+    async def should_compact(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        state: CompactionState | None = None,
+    ) -> bool:
+        non_system = [m for m in messages if m.get("role") != "system"]
+        if len(non_system) >= self._threshold:
+            return True
+        if self._context_limit > 0:
+            estimated = self._estimate_tokens(messages)
+            if estimated > self._context_limit - self._reserve_tokens:
+                return True
+        return False
+
+    async def compact(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        state: CompactionState | None = None,
+    ) -> CompactionResult:
+        original_count = len(messages)
+
+        system_msgs = [m for m in messages if m.get("role") == "system"]
+        non_system = [m for m in messages if m.get("role") != "system"]
+
+        if not non_system:
+            return CompactionResult(
+                messages=messages,
+                original_count=original_count,
+                compacted_count=original_count,
+                skipped=True,
+                skip_reason="no_non_system_messages",
+            )
+
+        # Walk backward to find the boundary preserving keep_recent_turns
+        # user/assistant exchange pairs.
+        preserve_idx = len(non_system)
+        pairs_found = 0
+        i = len(non_system) - 1
+        while i >= 0 and pairs_found < self._keep_recent:
+            msg = non_system[i]
+            if msg.get("role") == "user":
+                pairs_found += 1
+                preserve_idx = i
+            i -= 1
+
+        preserved = non_system[preserve_idx:]
+        compactable = non_system[:preserve_idx]
+
+        # Tool-call pairing guard: ensure tool_calls and their results
+        # are never split across the compactable/preserved boundary.
+        preserved_call_ids: set[str] = set()
+        for m in preserved:
+            for tc in m.get("tool_calls", []):
+                tc_id = tc.get("id", "")
+                if tc_id:
+                    preserved_call_ids.add(tc_id)
+
+        # Move tool results from compactable whose call is in preserved.
+        moved_to_preserved: list[int] = []
+        for idx, m in enumerate(compactable):
+            if m.get("role") == "tool" and m.get("tool_call_id") in preserved_call_ids:
+                moved_to_preserved.append(idx)
+
+        # Move tool_calls assistants from compactable whose results are
+        # in preserved.
+        preserved_result_ids: set[str] = set()
+        for m in preserved:
+            if m.get("role") == "tool" and m.get("tool_call_id"):
+                preserved_result_ids.add(m["tool_call_id"])
+        for idx, m in enumerate(compactable):
+            if m.get("role") == "assistant" and m.get("tool_calls"):
+                for tc in m["tool_calls"]:
+                    if tc.get("id") in preserved_result_ids:
+                        if idx not in moved_to_preserved:
+                            moved_to_preserved.append(idx)
+                        break
+
+        if moved_to_preserved:
+            # Extend the boundary backward to include all moved messages.
+            # The simplest correct approach: find the lowest index that
+            # needs to move, then move *everything* from there onward
+            # into preserved.
+            new_boundary = min(moved_to_preserved)
+            preserved = non_system[new_boundary:]
+            compactable = non_system[:new_boundary]
+
+        # Pending-state guard: skip if any compactable message contains
+        # pending sentinels.
+        for m in compactable:
+            content = m.get("content", "")
+            if isinstance(content, str) and (
+                "__pending__" in content or "__permission_pending__" in content
+            ):
+                return CompactionResult(
+                    messages=messages,
+                    original_count=original_count,
+                    compacted_count=original_count,
+                    skipped=True,
+                    skip_reason="pending_state",
+                )
+
+        if not compactable:
+            return CompactionResult(
+                messages=messages,
+                original_count=original_count,
+                compacted_count=original_count,
+                skipped=True,
+                skip_reason="nothing_to_compact",
+            )
+
+        # Build the summary prompt and call the LLM.
+        serialized = json.dumps(compactable, indent=2, default=str)
+        summary_messages = [
+            {"role": "system", "content": _SUMMARY_PROMPT},
+            {"role": "user", "content": serialized},
+        ]
+
+        try:
+            summary_text = await self._model_fn(summary_messages)
+        except Exception:
+            logger.exception("LLM compaction failed; returning original messages")
+            return CompactionResult(
+                messages=messages,
+                original_count=original_count,
+                compacted_count=original_count,
+                skipped=True,
+                skip_reason="llm_error",
+            )
+
+        summary_msg: dict[str, Any] = {
+            "role": self._summary_role,
+            "content": summary_text,
+        }
+
+        compacted = system_msgs + [summary_msg] + preserved
+        return CompactionResult(
+            messages=compacted,
+            original_count=original_count,
+            compacted_count=len(compacted),
+        )
+
+
 def create_compactor(
     backend: str | None = None,
+    *,
+    model_fn: Any | None = None,
     **kwargs: Any,
 ) -> Compactor:
-    """Create a compactor from config. Only ``null`` for now; #166 adds ``llm``."""
+    """Create a compactor from config."""
     if backend is None or backend == "null":
         return NullCompactor()
+    if backend == "llm":
+        if model_fn is None:
+            raise ValueError("LLMCompactor requires a model_fn callable")
+        return LLMCompactor(model_fn, **kwargs)
     raise ValueError(f"Unknown compactor backend: {backend!r}")

--- a/packages/fipsagents/tests/test_compactor.py
+++ b/packages/fipsagents/tests/test_compactor.py
@@ -1,8 +1,9 @@
-"""Tests for Compactor ABC and NullCompactor."""
+"""Tests for Compactor ABC, NullCompactor, and LLMCompactor."""
 import pytest
 from fipsagents.server.compactor import (
     CompactionResult,
     CompactionState,
+    LLMCompactor,
     NullCompactor,
     create_compactor,
 )
@@ -62,3 +63,146 @@ class TestCreateCompactor:
     def test_unknown_raises(self):
         with pytest.raises(ValueError, match="Unknown compactor"):
             create_compactor("nonexistent")
+
+
+# -- LLMCompactor tests ---------------------------------------------------
+
+async def _mock_model_fn(messages):
+    return "**Goal**: Test goal\n**Progress**: Done testing."
+
+
+async def _failing_model_fn(messages):
+    raise RuntimeError("LLM unavailable")
+
+
+def _make_conversation(n_user_turns: int) -> list[dict]:
+    """Build a conversation with n user/assistant pairs."""
+    msgs: list[dict] = [{"role": "system", "content": "You are helpful."}]
+    for i in range(n_user_turns):
+        msgs.append({"role": "user", "content": f"Question {i}"})
+        msgs.append({"role": "assistant", "content": f"Answer {i}"})
+    return msgs
+
+
+class TestLLMCompactorShouldCompact:
+    @pytest.mark.asyncio
+    async def test_threshold_triggers(self):
+        c = LLMCompactor(_mock_model_fn, threshold_messages=5)
+        msgs = _make_conversation(3)  # 1 system + 6 non-system = 7 non-system msgs
+        assert await c.should_compact(msgs) is True
+
+    @pytest.mark.asyncio
+    async def test_under_threshold_no_trigger(self):
+        c = LLMCompactor(_mock_model_fn, threshold_messages=50)
+        msgs = _make_conversation(3)
+        assert await c.should_compact(msgs) is False
+
+    @pytest.mark.asyncio
+    async def test_context_limit_triggers(self):
+        c = LLMCompactor(
+            _mock_model_fn,
+            threshold_messages=999,
+            context_limit=10,
+            reserve_tokens=5,
+        )
+        msgs = _make_conversation(3)
+        assert await c.should_compact(msgs) is True
+
+
+class TestLLMCompactorCompact:
+    @pytest.mark.asyncio
+    async def test_preserves_recent_turns(self):
+        c = LLMCompactor(_mock_model_fn, threshold_messages=5, keep_recent_turns=2)
+        msgs = _make_conversation(5)
+        result = await c.compact(msgs)
+        assert not result.skipped
+        # System msg + summary msg + last 2 user/assistant pairs (4 msgs)
+        assert result.compacted_count == 1 + 1 + 4
+
+        # The last two user messages should be in the result.
+        user_msgs = [m for m in result.messages if m.get("role") == "user"]
+        assert user_msgs[-1]["content"] == "Question 4"
+        assert user_msgs[-2]["content"] == "Question 3"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_pairing(self):
+        """Tool call results should not be split from their tool_calls."""
+        c = LLMCompactor(_mock_model_fn, threshold_messages=5, keep_recent_turns=1)
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q0"},
+            {"role": "assistant", "content": "a0"},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "tc_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+        result = await c.compact(msgs)
+        assert not result.skipped
+        # The tool_calls assistant and its tool result should both be
+        # either compacted or preserved together.
+        preserved_ids = {
+            m.get("tool_call_id") for m in result.messages if m.get("role") == "tool"
+        }
+        preserved_tc_ids = set()
+        for m in result.messages:
+            for tc in m.get("tool_calls", []):
+                preserved_tc_ids.add(tc["id"])
+        # If tool_calls assistant is preserved, its tool result must also be.
+        for tc_id in preserved_tc_ids:
+            assert tc_id in preserved_ids
+
+    @pytest.mark.asyncio
+    async def test_pending_state_skip(self):
+        c = LLMCompactor(_mock_model_fn, threshold_messages=3, keep_recent_turns=1)
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q0"},
+            {"role": "assistant", "content": '{"__pending__": true}'},
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+        ]
+        result = await c.compact(msgs)
+        assert result.skipped is True
+        assert result.skip_reason == "pending_state"
+
+    @pytest.mark.asyncio
+    async def test_llm_error_fallback(self):
+        c = LLMCompactor(_failing_model_fn, threshold_messages=3, keep_recent_turns=1)
+        msgs = _make_conversation(3)
+        result = await c.compact(msgs)
+        assert result.skipped is True
+        assert result.skip_reason == "llm_error"
+        assert result.messages is msgs
+
+    @pytest.mark.asyncio
+    async def test_summary_message_role(self):
+        c = LLMCompactor(
+            _mock_model_fn,
+            threshold_messages=3,
+            keep_recent_turns=1,
+            summary_role="system",
+        )
+        msgs = _make_conversation(3)
+        result = await c.compact(msgs)
+        assert not result.skipped
+        summary = [
+            m for m in result.messages
+            if m.get("content", "").startswith("**Goal**")
+        ]
+        assert len(summary) == 1
+        assert summary[0]["role"] == "system"
+
+
+class TestCreateCompactorLLM:
+    def test_llm_backend_creates_llm_compactor(self):
+        c = create_compactor("llm", model_fn=_mock_model_fn, threshold_messages=10)
+        assert isinstance(c, LLMCompactor)
+
+    def test_llm_backend_without_model_fn_raises(self):
+        with pytest.raises(ValueError, match="model_fn"):
+            create_compactor("llm")


### PR DESCRIPTION
## Summary

- `LLMCompactor` summarises older messages into a structured briefing when conversation length exceeds threshold
- Tool-call pairing guard ensures `tool_calls`/`tool` result pairs are never split across the compaction boundary
- Pending-state guard skips compaction when `__pending__` or `__permission_pending__` sentinels exist
- On LLM failure, returns original messages unchanged (no data loss)
- Server integration via `_maybe_compact()` helper called before `astep_stream()` in both sync and streaming paths
- `summary_model` config allows using a cheaper model for summarization

## Config

```yaml
server:
  compaction:
    enabled: true
    backend: llm
    threshold_messages: 50
    keep_recent_turns: 4
    summary_role: developer
    summary_model: ${COMPACTION_MODEL:-}  # defaults to agent's model
    context_limit: 0       # 0 = message-count trigger only
    reserve_tokens: 4000
```

## Test plan

- [x] Message-count threshold triggers compaction
- [x] Context-limit (token-based) threshold triggers
- [x] Under-threshold: no trigger
- [x] Tool-call pairing guard prevents splitting tool_calls from results
- [x] Pending-state guard skips when sentinels present
- [x] LLM error fallback returns original messages
- [x] Summary message uses configured role
- [x] Factory creates LLMCompactor for `backend: llm`
- [x] Factory requires `model_fn` for LLM backend
- [x] No compactable messages: skip gracefully
- [x] Full test suite: no regressions (1692 passed)

Closes #166