### PR TITLE
chore: session-close fixes — lint, docs, version bump to 0.24.0

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,6 +364,40 @@ Multi-agent deployments (workflow graphs with `RemoteNode`) propagate trace cont
 
 The result is a single trace tree spanning all agents in a workflow, viewable in any W3C-compliant trace backend (Jaeger, Tempo, the OTEL collector).
 
+## Event-Triggered Mode
+
+Event-triggered mode allows agents to respond to external events (webhooks, cron schedules) rather than only serving synchronous HTTP requests. Configure one or more `EventSource`s in `agent.yaml` under `server.event_sources`; the server spawns one `asyncio.Task` per source at startup, each polling or listening for events and translating them to chat-completion requests.
+
+### Event Sources
+
+**`HttpWebhookSource`** listens on `POST /v1/events` with HMAC-SHA256 signature validation (`X-Signature-256` header). The caller POSTs JSON; the source validates the signature, extracts the event payload, and passes it to the configured translator function.
+
+**`CronSource`** runs on a POSIX cron schedule (5-field: minute, hour, day-of-month, month, day-of-week). At each trigger time, it invokes the translator with an empty event payload.
+
+Phase 1b event sources (Kafka, Redis Pub/Sub) are deferred behind pip extras for targeted dependency installs.
+
+### Event Sink
+
+The `EventSink` receives the agent's response after processing. Three implementations ship in Phase 1a:
+
+- **`NullSink`** — silent discard (useful for cron tasks that persist their own state)
+- **`LogSink`** — structured JSON log line at INFO level
+- **`HttpCallbackSink`** — POST to a configured URL with the response body and optional headers
+
+Configure the sink via `server.event_sink` (discriminated union on `type`).
+
+### Translation and Integration
+
+`default_translate_event(event_data)` is a server-layer function (not a BaseAgent method) that constructs a `ChatCompletionRequest` from the event payload. It lives in `fipsagents.server.events` and is the default translator for both sources. Custom translators can be registered per-source via the `translator` config field.
+
+The server integration reuses `_collect_sync()` — the same code path that handles HTTP requests — so all server-layer features (session lock, compaction, permissions, cost tracking) apply uniformly to event-triggered requests. Event-triggered sessions are keyed with an `event:` prefix (`event:{source_name}:{deterministic_id}`) to namespace them separately from user-initiated sessions.
+
+### Retry and Observability
+
+Transient failures (network errors, 5xx from the sink) retry with exponential backoff up to a configurable max attempts. Permanent failures (4xx, validation errors) are logged and dropped. Three `StreamEvent` variants surface event lifecycle: `EventReceived`, `EventProcessed`, `EventFailed`. Three Prometheus metrics track event volume, processing latency, and error rates.
+
+Full design in `planning/event-triggered-design.md`.
+
 ## Safety & Resilience
 
 Three features guard against runaway behavior in long-running or autonomous agent sessions. All are opt-in via `agent.yaml` and degrade to no-ops when unconfigured.
@@ -913,3 +947,13 @@ This is the least disruptive path that addresses the multi-agent rough edges wit
 - **Auth boundary between agents writing shared storage.** Needed if multi-tenant is in scope; otherwise punt and revisit when the second tenant arrives.
 - **Cross-agent session continuity** (a user's conversation following them across agents). Protocol question, not a storage question.
 - **Migrating traces to OTEL.** Already partially solved by `OTELTraceStore`; the platform's `TraceStore` can adopt it later without a topology change.
+
+## Session Fork and Revert
+
+`SessionStore.fork(session_id, from_message_index)` enables branch-point experimentation: copy messages `[0:from_message_index]` into a new session with `parent_session_id` lineage tracking, preserving the original session unchanged. `SessionStore.revert(session_id, to_message_index)` truncates in place, discarding messages after the specified index.
+
+REST endpoints: `POST /v1/sessions/{id}/fork` (returns the new session ID, 201 Created), `POST /v1/sessions/{id}/revert` (204 No Content). Both are server-layer operations — BaseAgent has no concept of forking or reverting.
+
+`NullSessionStore` raises `NotImplementedError` for both methods (sessions are ephemeral, no state to fork from). SQLite and Postgres implementations copy the messages list and metadata while resetting fork-specific fields (`parent_session_id`, `forked_at_message_id`, `created_at`, `updated_at`). Cost data is not inherited — the fork starts with fresh counters.
+
+Full design in `planning/session-state-compaction-design.md`.

--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fipsagents"
-version = "0.23.0"
+version = "0.24.0"
 description = "Production-ready AI agent framework for FIPS/OpenShift environments"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -1712,7 +1712,9 @@ class OpenAIChatServer:
 
         try:
             async for event in source.consume():
-                now_fn = lambda: datetime.now(tz=UTC)
+                def _now() -> datetime:
+                    return datetime.now(tz=UTC)
+
                 for attempt in range(retry_cfg.max_attempts):
                     try:
                         content = await self._process_event(event, source)
@@ -1721,7 +1723,7 @@ class OpenAIChatServer:
                             event_type="response",
                             payload={"content": content},
                             source=event.source,
-                            timestamp=now_fn(),
+                            timestamp=_now(),
                         ))
                         await source.acknowledge(event.event_id)
                         break
@@ -1751,7 +1753,7 @@ class OpenAIChatServer:
                             event_type="processing_failed",
                             payload={"error": traceback.format_exc()},
                             source=event.source,
-                            timestamp=now_fn(),
+                            timestamp=_now(),
                         ))
                         await source.acknowledge(event.event_id)
                         break

--- a/packages/fipsagents/src/fipsagents/server/events.py
+++ b/packages/fipsagents/src/fipsagents/server/events.py
@@ -21,6 +21,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from fipsagents.baseagent.config import EventRetryConfig as RetryConfig  # noqa: F401
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,12 +50,6 @@ class OutboundEvent(BaseModel):
     source: str
     timestamp: datetime
     metadata: dict[str, Any] = Field(default_factory=dict)
-
-
-
-# Canonical definition is EventRetryConfig in fipsagents.baseagent.config.
-# Re-exported here as RetryConfig for convenience.
-from fipsagents.baseagent.config import EventRetryConfig as RetryConfig
 
 
 

--- a/packages/fipsagents/src/fipsagents/server/sources/cron.py
+++ b/packages/fipsagents/src/fipsagents/server/sources/cron.py
@@ -9,7 +9,6 @@ macros, a seconds field, or ``L``/``W``/``#`` extensions.
 from __future__ import annotations
 
 import asyncio
-import calendar
 import logging
 from collections.abc import AsyncIterator
 from datetime import datetime, timedelta, timezone

--- a/packages/fipsagents/tests/unit/test_cron_parser.py
+++ b/packages/fipsagents/tests/unit/test_cron_parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 

--- a/packages/fipsagents/tests/unit/test_event_integration.py
+++ b/packages/fipsagents/tests/unit/test_event_integration.py
@@ -6,9 +6,7 @@ import asyncio
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock
 
 from fipsagents.baseagent.config import ServerConfig
 from fipsagents.server.events import (

--- a/packages/fipsagents/tests/unit/test_event_sinks.py
+++ b/packages/fipsagents/tests/unit/test_event_sinks.py
@@ -200,9 +200,6 @@ class TestHttpCallbackSink:
         sink = HttpCallbackSink(config=cfg)
         assert sink._client is None
 
-        # Replace with mock after lazy creation would happen
-        original_emit = sink.emit
-
         async def patched_emit(event):
             # Trigger lazy creation, then swap the client
             if sink._client is None:

--- a/packages/fipsagents/tests/unit/test_events_abc.py
+++ b/packages/fipsagents/tests/unit/test_events_abc.py
@@ -15,8 +15,6 @@ from fipsagents.baseagent.events import (
     StreamEvent,
 )
 from fipsagents.server.events import (
-    EventSink,
-    EventSource,
     InboundEvent,
     OutboundEvent,
     RetryConfig,


### PR DESCRIPTION
## Summary

- Fix 10 ruff lint errors across event-triggered mode files (unused imports, lambda assignment, import ordering)
- Update `docs/architecture.md` with event-triggered mode (#188) and session fork (#168) subsections
- Bump version 0.23.0 → 0.24.0

## Test plan

- [x] `ruff check` passes with zero errors
- [x] 155 affected tests pass