### PR TITLE
Add max_injection_tokens guard to prevent context overflow on file injection

### DIFF
--- a/packages/fipsagents/pyproject.toml
+++ b/packages/fipsagents/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fipsagents"
-version = "0.31.0"
+version = "0.31.1"
 description = "Production-ready AI agent framework for FIPS/OpenShift environments"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/packages/fipsagents/src/fipsagents/baseagent/config.py
+++ b/packages/fipsagents/src/fipsagents/baseagent/config.py
@@ -1107,10 +1107,20 @@ class FilesConfig(_PerStoreBackendMixin):
     ``parser.pdf.do_ocr`` to ``False`` -- text-extractable PDFs parse in
     sub-second instead of multiple minutes. Operators with scanned
     PDFs set ``do_ocr: true``.
+
+    ``max_injection_tokens`` caps how many tokens of extracted text
+    the full-text injection path inserts per file.  When the extracted
+    text exceeds this limit it is truncated and a note is appended
+    directing operators to enable chunking for full-content retrieval.
+    This prevents oversized documents from blowing out the model's
+    context window (which causes vLLM to compute a negative
+    ``max_tokens`` and reject the request).  Set to ``0`` to disable
+    the guard entirely.
     """
 
     enabled: bool = False
     max_file_size_bytes: int = Field(default=50 * 1024 * 1024, ge=1)
+    max_injection_tokens: int = Field(default=100_000, ge=0)
     bytes_dir: str = "./files"
     bytes_backend: BytesBackendConfig = Field(default_factory=BytesBackendConfig)
     sqlite_path: str = ""

--- a/packages/fipsagents/src/fipsagents/server/app.py
+++ b/packages/fipsagents/src/fipsagents/server/app.py
@@ -1333,9 +1333,27 @@ class OpenAIChatServer:
                 # leaving the model with nothing.
 
             if record.extracted_text:
+                text = record.extracted_text
+                max_tok = files_cfg.max_injection_tokens
+                if max_tok > 0:
+                    tok_count = count_tokens(text)
+                    if tok_count > max_tok:
+                        # Character-based first cut (~4 chars/token) to
+                        # avoid re-counting the full text.
+                        text = text[: max_tok * 4]
+                        # Verify and trim further if the estimate was
+                        # too generous.
+                        while count_tokens(text) > max_tok:
+                            text = text[: int(len(text) * 0.9)]
+                        omitted = tok_count - count_tokens(text)
+                        text += (
+                            f"\n\n[... content truncated — {omitted} "
+                            "tokens omitted. Enable chunking for "
+                            "full-content retrieval.]"
+                        )
                 messages.append({
                     "role": "system",
-                    "content": f"{header}\n{record.extracted_text}",
+                    "content": f"{header}\n{text}",
                 })
             else:
                 messages.append({

--- a/packages/fipsagents/tests/test_files_chunking.py
+++ b/packages/fipsagents/tests/test_files_chunking.py
@@ -511,3 +511,115 @@ class TestShutdownDrainsTasks:
         # After context exit, lifespan shutdown ran. The slow save
         # should have completed before the chunk store was closed.
         assert stub.save_chunks.await_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# max_injection_tokens config and truncation
+# ---------------------------------------------------------------------------
+
+
+class TestMaxInjectionTokensConfig:
+    def test_default_value(self):
+        cfg = FilesConfig()
+        assert cfg.max_injection_tokens == 100_000
+
+    def test_custom_value(self):
+        cfg = FilesConfig(max_injection_tokens=500)
+        assert cfg.max_injection_tokens == 500
+
+    def test_zero_disables_guard(self):
+        cfg = FilesConfig(max_injection_tokens=0)
+        assert cfg.max_injection_tokens == 0
+
+    def test_negative_rejected(self):
+        with pytest.raises(ValueError):
+            FilesConfig(max_injection_tokens=-1)
+
+
+class TestInjectionTruncation:
+    @pytest.mark.asyncio
+    async def test_short_text_injected_in_full(self, tmp_path):
+        """Text under the token limit is injected without truncation."""
+        server, stub = _build_server_with_chunking(
+            tmp_path, enabled=False, threshold=10_000,
+        )
+        short_text = "This is a small document."
+        with TestClient(server.app) as _:
+            server._agent.config.server.files.max_injection_tokens = 1000
+            await server._file_store.save(  # type: ignore[union-attr]
+                FileRecord(
+                    file_id="f1", filename="small.txt", mime_type="text/plain",
+                    size_bytes=len(short_text), sha256="",
+                    extracted_text=short_text,
+                    parse_status="completed",
+                    chunk_status="skipped",
+                    chunk_count=0,
+                ),
+                short_text.encode(),
+            )
+            msgs = await server._resolve_file_attachments(
+                ["f1"], last_user_message="query",
+            )
+        assert len(msgs) == 1
+        assert short_text in msgs[0]["content"]
+        assert "truncated" not in msgs[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_large_text_truncated_with_note(self, tmp_path):
+        """Text over the token limit is truncated and a note is appended."""
+        server, stub = _build_server_with_chunking(
+            tmp_path, enabled=False, threshold=10_000,
+        )
+        # Build text that is well over 10 tokens (our test limit).
+        big_text = "word " * 500  # ~500 tokens
+        with TestClient(server.app) as _:
+            server._agent.config.server.files.max_injection_tokens = 10
+            await server._file_store.save(  # type: ignore[union-attr]
+                FileRecord(
+                    file_id="f2", filename="big.txt", mime_type="text/plain",
+                    size_bytes=len(big_text), sha256="",
+                    extracted_text=big_text,
+                    parse_status="completed",
+                    chunk_status="skipped",
+                    chunk_count=0,
+                ),
+                big_text.encode(),
+            )
+            msgs = await server._resolve_file_attachments(
+                ["f2"], last_user_message="query",
+            )
+        assert len(msgs) == 1
+        content = msgs[0]["content"]
+        # The truncation note must be present.
+        assert "content truncated" in content
+        assert "tokens omitted" in content
+        assert "Enable chunking" in content
+        # The full text should NOT be present.
+        assert content != f"[Attached file: big.txt (text/plain, {len(big_text)} bytes)]\n{big_text}"
+
+    @pytest.mark.asyncio
+    async def test_zero_limit_disables_truncation(self, tmp_path):
+        """max_injection_tokens=0 means no guard; full text injected."""
+        server, stub = _build_server_with_chunking(
+            tmp_path, enabled=False, threshold=10_000,
+        )
+        big_text = "word " * 500
+        with TestClient(server.app) as _:
+            server._agent.config.server.files.max_injection_tokens = 0
+            await server._file_store.save(  # type: ignore[union-attr]
+                FileRecord(
+                    file_id="f3", filename="huge.txt", mime_type="text/plain",
+                    size_bytes=len(big_text), sha256="",
+                    extracted_text=big_text,
+                    parse_status="completed",
+                    chunk_status="skipped",
+                    chunk_count=0,
+                ),
+                big_text.encode(),
+            )
+            msgs = await server._resolve_file_attachments(
+                ["f3"], last_user_message="query",
+            )
+        assert len(msgs) == 1
+        assert big_text in msgs[0]["content"]
+        assert "truncated" not in msgs[0]["content"]

--- a/packages/fipsagents/tests/test_server_openai.py
+++ b/packages/fipsagents/tests/test_server_openai.py
@@ -97,6 +97,7 @@ class _StubAgent(BaseAgent):
                 files=types.SimpleNamespace(
                     enabled=False,
                     max_file_size_bytes=50 * 1024 * 1024,
+                    max_injection_tokens=100_000,
                     bytes_dir="./files",
                     sqlite_path="",
                     allowed_mime_types=[],

--- a/templates/agent-loop/agent.yaml
+++ b/templates/agent-loop/agent.yaml
@@ -341,6 +341,7 @@ server:
     enabled: ${FILES_ENABLED:-false}
     backend: ${FILES_BACKEND:-}
     max_file_size_bytes: ${FILES_MAX_SIZE_BYTES:-52428800}  # 50 MiB
+    max_injection_tokens: ${FILES_MAX_INJECTION_TOKENS:-100000}
     # bytes_dir is the local-FS path SqliteFileStore / PostgresFileStore
     # write bytes to. Mount a PVC at this path in production (the Helm
     # chart sets FILES_BYTES_DIR via files.persistence.mountPath);


### PR DESCRIPTION
## Summary

- Add `max_injection_tokens` config field to `FilesConfig` (default 100,000 tokens) that caps how much extracted text the full-text injection path inserts per file
- When text exceeds the limit, truncate and append a note directing operators to enable chunking
- Set to `0` to disable the guard entirely (backward compatible)

This prevents large file uploads from exceeding the model's context window when chunking is disabled, which causes vLLM to compute a negative `max_tokens` and return a cryptic 400 error.

Config: `server.files.max_injection_tokens`
Env var: `FILES_MAX_INJECTION_TOKENS`

Fixes #221

## Test plan

- [x] 7 new tests: config defaults, custom values, zero-disables, negative-rejected, short text injected in full, large text truncated with note, zero limit disables truncation
- [x] All existing tests pass (2415 passed, 26 skipped)
- [x] Updated test stub in test_server_openai.py for consistency